### PR TITLE
Add rack-aware load balancing policy

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2214,6 +2214,73 @@ cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster,
                                          cass_bool_t allow_remote_dcs_for_local_cl);
 
 /**
+ * Configures the cluster to use Rack-aware load balancing.
+ * For each query, all live nodes in a primary 'local' rack are tried first,
+ * followed by nodes from local DC and then any node from other DCs.
+ *
+ * <b>Note:</b> This is the default, and does not need to be called unless
+ * switching an existing from another policy or changing settings.
+ * Without further configuration, a default local_dc and local_rack
+ * is chosen from the first connected contact point,
+ * and no remote hosts are considered in query plans.
+ * If relying on this mechanism, be sure to use only contact
+ * points from the local DC.
+ *
+ * @deprecated The remote DC settings for DC-aware are not suitable for most
+ * scenarios that require DC failover. There is also unhandled gap between
+ * replication factor number of nodes failing and the full cluster failing. Only
+ * the remote DC settings are being deprecated.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc The primary data center to try first
+ * @param[in] local_rack The primary rack to try first
+ * @param[in] used_hosts_per_remote_dc The number of hosts used in each remote
+ * DC if no hosts are available in the local dc (<b>deprecated</b>)
+ * @param[in] allow_remote_dcs_for_local_cl Allows remote hosts to be used if no
+ * local dc hosts are available and the consistency level is LOCAL_ONE or
+ * LOCAL_QUORUM (<b>deprecated</b>)
+ * @return CASS_OK if successful, otherwise an error occurred
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware(CassCluster* cluster,
+                                       const char* local_dc,
+                                       const char* local_rack,
+                                       unsigned used_hosts_per_remote_dc,
+                                       cass_bool_t allow_remote_dcs_for_local_cl);
+
+
+/**
+ * Same as cass_cluster_set_load_balance_rack_aware(), but with lengths for string
+ * parameters.
+ *
+ * @deprecated The remote DC settings for DC-aware are not suitable for most
+ * scenarios that require DC failover. There is also unhandled gap between
+ * replication factor number of nodes failing and the full cluster failing. Only
+ * the remote DC settings are being deprecated.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc
+ * @param[in] local_dc_length
+ * @param[in] used_hosts_per_remote_dc (<b>deprecated</b>)
+ * @param[in] allow_remote_dcs_for_local_cl (<b>deprecated</b>)
+ * @return same as cass_cluster_set_load_balance_dc_aware()
+ *
+ * @see cass_cluster_set_load_balance_dc_aware()
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster,
+                                         const char* local_dc,
+                                         size_t local_dc_length,
+                                         const char* local_rack,
+                                         size_t local_rack_length,
+                                         unsigned used_hosts_per_remote_dc,
+                                         cass_bool_t allow_remote_dcs_for_local_cl);
+
+/**
  * Configures the cluster to use token-aware request routing or not.
  *
  * <b>Important:</b> Token-aware routing depends on keyspace metadata.

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -3243,6 +3243,16 @@ cass_session_get_speculative_execution_metrics(const CassSession* session,
                                                CassSpeculativeExecutionMetrics* output);
 
 /**
+ * Gets the current count of inflight request to all hosts.
+ *
+ * @public @memberof CassSession
+ *
+ * @param[in] session
+ */
+CASS_EXPORT cass_uint64_t
+cass_session_get_inflight_request_count(const CassSession* session);
+
+/**
  * Get the client id.
  *
  * @public @memberof CassSession

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2226,47 +2226,28 @@ cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster,
  * If relying on this mechanism, be sure to use only contact
  * points from the local DC.
  *
- * @deprecated The remote DC settings for DC-aware are not suitable for most
- * scenarios that require DC failover. There is also unhandled gap between
- * replication factor number of nodes failing and the full cluster failing. Only
- * the remote DC settings are being deprecated.
- *
  * @public @memberof CassCluster
  *
  * @param[in] cluster
  * @param[in] local_dc The primary data center to try first
  * @param[in] local_rack The primary rack to try first
- * @param[in] used_hosts_per_remote_dc The number of hosts used in each remote
- * DC if no hosts are available in the local dc (<b>deprecated</b>)
- * @param[in] allow_remote_dcs_for_local_cl Allows remote hosts to be used if no
- * local dc hosts are available and the consistency level is LOCAL_ONE or
- * LOCAL_QUORUM (<b>deprecated</b>)
  * @return CASS_OK if successful, otherwise an error occurred
  */
 CASS_EXPORT CassError
 cass_cluster_set_load_balance_rack_aware(CassCluster* cluster,
                                        const char* local_dc,
-                                       const char* local_rack,
-                                       unsigned used_hosts_per_remote_dc,
-                                       cass_bool_t allow_remote_dcs_for_local_cl);
+                                       const char* local_rack);
 
 
 /**
  * Same as cass_cluster_set_load_balance_rack_aware(), but with lengths for string
  * parameters.
  *
- * @deprecated The remote DC settings for DC-aware are not suitable for most
- * scenarios that require DC failover. There is also unhandled gap between
- * replication factor number of nodes failing and the full cluster failing. Only
- * the remote DC settings are being deprecated.
- *
  * @public @memberof CassCluster
  *
  * @param[in] cluster
  * @param[in] local_dc
  * @param[in] local_dc_length
- * @param[in] used_hosts_per_remote_dc (<b>deprecated</b>)
- * @param[in] allow_remote_dcs_for_local_cl (<b>deprecated</b>)
  * @return same as cass_cluster_set_load_balance_dc_aware()
  *
  * @see cass_cluster_set_load_balance_dc_aware()
@@ -2276,9 +2257,7 @@ cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster,
                                          const char* local_dc,
                                          size_t local_dc_length,
                                          const char* local_rack,
-                                         size_t local_rack_length,
-                                         unsigned used_hosts_per_remote_dc,
-                                         cass_bool_t allow_remote_dcs_for_local_cl);
+                                         size_t local_rack_length);
 
 /**
  * Configures the cluster to use token-aware request routing or not.

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2216,15 +2216,13 @@ cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster,
 /**
  * Configures the cluster to use Rack-aware load balancing.
  * For each query, all live nodes in a primary 'local' rack are tried first,
- * followed by nodes from local DC and then any node from other DCs.
+ * followed by nodes from local DC and then nodes from other DCs.
  *
- * <b>Note:</b> This is the default, and does not need to be called unless
- * switching an existing from another policy or changing settings.
- * Without further configuration, a default local_dc and local_rack
+ * With empty local_rack and local_dc,  default local_dc and local_rack
  * is chosen from the first connected contact point,
  * and no remote hosts are considered in query plans.
  * If relying on this mechanism, be sure to use only contact
- * points from the local DC.
+ * points from the local rack.
  *
  * @public @memberof CassCluster
  *

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -18,6 +18,7 @@
 
 #include "constants.hpp"
 #include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 #include "external.hpp"
 #include "logger.hpp"
 #include "resolver.hpp"
@@ -240,6 +241,7 @@ Cluster::Cluster(const ControlConnection::Ptr& connection, ClusterListener* list
                  const ControlConnectionSchema& schema,
                  const LoadBalancingPolicy::Ptr& load_balancing_policy,
                  const LoadBalancingPolicy::Vec& load_balancing_policies, const String& local_dc,
+		 const String& local_rack,
                  const StringMultimap& supported_options, const ClusterSettings& settings)
     : connection_(connection)
     , listener_(listener ? listener : &nop_cluster_listener__)
@@ -251,6 +253,7 @@ Cluster::Cluster(const ControlConnection::Ptr& connection, ClusterListener* list
     , connected_host_(connected_host)
     , hosts_(hosts)
     , local_dc_(local_dc)
+    , local_rack_(local_rack)
     , supported_options_(supported_options)
     , is_recording_events_(settings.disable_events_on_startup) {
   static const auto optimized_msg = "===== Using optimized driver!!! =====\n";

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -257,6 +257,7 @@ public:
    * determining the next control connection host.
    * @param load_balancing_policies
    * @param local_dc The local datacenter determined by the metadata service for initializing the
+   * @param local_rack The local rack determined by the metadata service for initializing the
    * load balancing policies.
    * @param supported_options Supported options discovered during control connection.
    * @param settings The control connection settings to use for reconnecting the
@@ -267,6 +268,7 @@ public:
           const ControlConnectionSchema& schema,
           const LoadBalancingPolicy::Ptr& load_balancing_policy,
           const LoadBalancingPolicy::Vec& load_balancing_policies, const String& local_dc,
+	  const String& local_rack,
           const StringMultimap& supported_options, const ClusterSettings& settings);
 
   /**
@@ -361,6 +363,7 @@ public:
   const Host::Ptr& connected_host() const { return connected_host_; }
   const TokenMap::Ptr& token_map() const { return token_map_; }
   const String& local_dc() const { return local_dc_; }
+  const String& local_rack() const { return local_rack_; }
   const VersionNumber& dse_server_version() const { return connection_->dse_server_version(); }
   const StringMultimap& supported_options() const { return supported_options_; }
   const ShardPortCalculator* shard_port_calculator() const { return shard_port_calculator_.get(); }
@@ -449,6 +452,7 @@ private:
   PreparedMetadata prepared_metadata_;
   TokenMap::Ptr token_map_;
   String local_dc_;
+  String local_rack_;
   StringMultimap supported_options_;
   Timer timer_;
   bool is_recording_events_;

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -300,7 +300,34 @@ CassError cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster, const c
       String(local_dc, local_dc_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
   return CASS_OK;
 }
+/*
+CassError cass_cluster_set_load_balance_rack_aware(CassCluster* cluster, const char* local_dc,
+                                                 const char* local_rack,
+                                                 unsigned used_hosts_per_remote_dc,
+                                                 cass_bool_t allow_remote_dcs_for_local_cl) {
+  if (local_dc == NULL || local_rack == NULL) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  return cass_cluster_set_load_balance_rack_aware_n(cluster, local_dc, SAFE_STRLEN(local_dc),
+                                                  local_rack, SAFE_STRLEN(local_rack),
+                                                  used_hosts_per_remote_dc,
+                                                  allow_remote_dcs_for_local_cl);
+}
 
+CassError cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster, const char* local_dc,
+                                                   size_t local_dc_length,
+                                                   const char* local_rack,
+                                                   size_t local_rack_length,
+                                                   unsigned used_hosts_per_remote_dc,
+                                                   cass_bool_t allow_remote_dcs_for_local_cl) {
+  if (local_dc == NULL || local_dc_length == 0 || local_rack == NULL || local_rack_length == 0) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  cluster->config().set_load_balancing_policy(new RackAwarePolicy(
+      String(local_dc, local_dc_length), String(local_rack, local_rack_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
+  return CASS_OK;
+}
+*/
 void cass_cluster_set_token_aware_routing(CassCluster* cluster, cass_bool_t enabled) {
   cluster->config().set_token_aware_routing(enabled == cass_true);
 }

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -302,29 +302,23 @@ CassError cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster, const c
 }
 
 CassError cass_cluster_set_load_balance_rack_aware(CassCluster* cluster, const char* local_dc,
-                                                 const char* local_rack,
-                                                 unsigned used_hosts_per_remote_dc,
-                                                 cass_bool_t allow_remote_dcs_for_local_cl) {
+                                                 const char* local_rack) {
   if (local_dc == NULL || local_rack == NULL) {
     return CASS_ERROR_LIB_BAD_PARAMS;
   }
   return cass_cluster_set_load_balance_rack_aware_n(cluster, local_dc, SAFE_STRLEN(local_dc),
-                                                  local_rack, SAFE_STRLEN(local_rack),
-                                                  used_hosts_per_remote_dc,
-                                                  allow_remote_dcs_for_local_cl);
+                                                  local_rack, SAFE_STRLEN(local_rack));
 }
 
 CassError cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster, const char* local_dc,
                                                    size_t local_dc_length,
                                                    const char* local_rack,
-                                                   size_t local_rack_length,
-                                                   unsigned used_hosts_per_remote_dc,
-                                                   cass_bool_t allow_remote_dcs_for_local_cl) {
+                                                   size_t local_rack_length) {
   if (local_dc == NULL || local_dc_length == 0 || local_rack == NULL || local_rack_length == 0) {
     return CASS_ERROR_LIB_BAD_PARAMS;
   }
   cluster->config().set_load_balancing_policy(new RackAwarePolicy(
-      String(local_dc, local_dc_length), String(local_rack, local_rack_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
+      String(local_dc, local_dc_length), String(local_rack, local_rack_length)));
   return CASS_OK;
 }
 

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -300,7 +300,7 @@ CassError cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster, const c
       String(local_dc, local_dc_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
   return CASS_OK;
 }
-/*
+
 CassError cass_cluster_set_load_balance_rack_aware(CassCluster* cluster, const char* local_dc,
                                                  const char* local_rack,
                                                  unsigned used_hosts_per_remote_dc,
@@ -327,7 +327,7 @@ CassError cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster, const
       String(local_dc, local_dc_length), String(local_rack, local_rack_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
   return CASS_OK;
 }
-*/
+
 void cass_cluster_set_token_aware_routing(CassCluster* cluster, cass_bool_t enabled) {
   cluster->config().set_token_aware_routing(enabled == cass_true);
 }

--- a/src/cluster_connector.hpp
+++ b/src/cluster_connector.hpp
@@ -169,6 +169,7 @@ private:
   Random* random_;
   Metrics* metrics_;
   String local_dc_;
+  String local_rack_;
   ClusterSettings settings_;
 
   Callback callback_;

--- a/src/cluster_metadata_resolver.hpp
+++ b/src/cluster_metadata_resolver.hpp
@@ -48,6 +48,7 @@ public:
 
   const AddressVec& resolved_contact_points() const { return resolved_contact_points_; }
   const String& local_dc() const { return local_dc_; }
+  const String& local_rack() const { return local_rack_; }
 
 protected:
   virtual void internal_resolve(uv_loop_t* loop, const AddressVec& contact_points) = 0;
@@ -57,6 +58,7 @@ protected:
 protected:
   AddressVec resolved_contact_points_;
   String local_dc_;
+  String local_rack_;
   Callback callback_;
 };
 

--- a/src/execution_profile.hpp
+++ b/src/execution_profile.hpp
@@ -23,6 +23,7 @@
 #include "cassandra.h"
 #include "constants.hpp"
 #include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 #include "dense_hash_map.hpp"
 #include "latency_aware_policy.hpp"
 #include "speculative_execution.hpp"

--- a/src/latency_aware_policy.cpp
+++ b/src/latency_aware_policy.cpp
@@ -27,13 +27,13 @@ using namespace datastax::internal;
 using namespace datastax::internal::core;
 
 void LatencyAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                              const String& local_dc) {
+                              const String& local_dc, const String& local_rack) {
   hosts_->reserve(hosts.size());
   std::transform(hosts.begin(), hosts.end(), std::back_inserter(*hosts_), GetHost());
   for (HostMap::const_iterator i = hosts.begin(), end = hosts.end(); i != end; ++i) {
     i->second->enable_latency_tracking(settings_.scale_ns, settings_.min_measured);
   }
-  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc);
+  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc, local_rack);
 }
 
 void LatencyAwarePolicy::register_handles(uv_loop_t* loop) { start_timer(loop); }

--- a/src/latency_aware_policy.hpp
+++ b/src/latency_aware_policy.hpp
@@ -51,7 +51,7 @@ public:
   virtual ~LatencyAwarePolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual void register_handles(uv_loop_t* loop);
   virtual void close_handles();

--- a/src/list_policy.cpp
+++ b/src/list_policy.cpp
@@ -23,7 +23,7 @@ using namespace datastax::internal;
 using namespace datastax::internal::core;
 
 void ListPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                      const String& local_dc) {
+                      const String& local_dc, const String& local_rack) {
   HostMap valid_hosts;
   for (HostMap::const_iterator i = hosts.begin(), end = hosts.end(); i != end; ++i) {
     const Host::Ptr& host = i->second;
@@ -36,7 +36,7 @@ void ListPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Ran
     LOG_ERROR("No valid hosts available for list policy");
   }
 
-  ChainedLoadBalancingPolicy::init(connected_host, valid_hosts, random, local_dc);
+  ChainedLoadBalancingPolicy::init(connected_host, valid_hosts, random, local_dc, local_rack);
 }
 
 CassHostDistance ListPolicy::distance(const Host::Ptr& host) const {

--- a/src/list_policy.hpp
+++ b/src/list_policy.hpp
@@ -31,7 +31,7 @@ public:
   virtual ~ListPolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual CassHostDistance distance(const Host::Ptr& host) const;
 

--- a/src/load_balancing.hpp
+++ b/src/load_balancing.hpp
@@ -43,6 +43,7 @@ typedef enum CassBalancingState_ {
 typedef enum CassHostDistance_ {
   CASS_HOST_DISTANCE_LOCAL,
   CASS_HOST_DISTANCE_REMOTE,
+  CASS_HOST_DISTANCE_REMOTE2,
   CASS_HOST_DISTANCE_IGNORE
 } CassHostDistance;
 

--- a/src/load_balancing.hpp
+++ b/src/load_balancing.hpp
@@ -87,7 +87,7 @@ public:
   virtual ~LoadBalancingPolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc) = 0;
+                    const String& local_dc, const String &local_rack) = 0;
 
   virtual void register_handles(uv_loop_t* loop) {}
   virtual void close_handles() {}
@@ -124,8 +124,8 @@ public:
   virtual ~ChainedLoadBalancingPolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc) {
-    return child_policy_->init(connected_host, hosts, random, local_dc);
+                    const String& local_dc, const String& local_rack) {
+    return child_policy_->init(connected_host, hosts, random, local_dc, local_rack);
   }
 
   virtual const LoadBalancingPolicy::Ptr& child_policy() const { return child_policy_; }

--- a/src/rack_aware_policy.hpp
+++ b/src/rack_aware_policy.hpp
@@ -58,22 +58,22 @@ public:
   }
 
 private:
-  class PerDCHostMap {
+  class PerKeyHostMap {
   public:
     typedef internal::Map<String, CopyOnWriteHostVec> Map;
     typedef Set<String> KeySet;
 
-    PerDCHostMap()
+    PerKeyHostMap()
         : no_hosts_(new HostVec()) {
       uv_rwlock_init(&rwlock_);
     }
-    ~PerDCHostMap() { uv_rwlock_destroy(&rwlock_); }
+    ~PerKeyHostMap() { uv_rwlock_destroy(&rwlock_); }
 
-    void add_host_to_dc(const String& dc, const Host::Ptr& host);
-    void remove_host_from_dc(const String& dc, const Host::Ptr& host);
+    void add_host_to_key(const String& key, const Host::Ptr& host);
+    void remove_host_from_key(const String& key, const Host::Ptr& host);
     bool remove_host(const Address& address);
-    const CopyOnWriteHostVec& get_hosts(const String& dc) const;
-    void copy_dcs(KeySet* dcs) const;
+    const CopyOnWriteHostVec& get_hosts(const String& key) const;
+    void copy_keys(KeySet* keys) const;
 
   private:
     Map map_;
@@ -81,11 +81,11 @@ private:
     const CopyOnWriteHostVec no_hosts_;
 
   private:
-    DISALLOW_COPY_AND_ASSIGN(PerDCHostMap);
+    DISALLOW_COPY_AND_ASSIGN(PerKeyHostMap);
   };
 
   const CopyOnWriteHostVec& get_local_dc_hosts() const;
-  void get_remote_dcs(PerDCHostMap::KeySet* remote_dcs) const;
+  void get_remote_dcs(PerKeyHostMap::KeySet* remote_dcs) const;
 
 public:
   class RackAwareQueryPlan : public QueryPlan {
@@ -98,7 +98,8 @@ public:
     const RackAwarePolicy* policy_;
     CassConsistency cl_;
     CopyOnWriteHostVec hosts_;
-    ScopedPtr<PerDCHostMap::KeySet> remote_dcs_;
+    ScopedPtr<PerKeyHostMap::KeySet> remote_racks_;
+    ScopedPtr<PerKeyHostMap::KeySet> remote_dcs_;
     size_t local_remaining_;
     size_t remote_remaining_;
     size_t index_;
@@ -111,8 +112,10 @@ private:
   String local_dc_;
   String local_rack_;
 
-  CopyOnWriteHostVec local_dc_live_hosts_;
-  PerDCHostMap per_remote_dc_live_hosts_;
+  CopyOnWriteHostVec local_rack_live_hosts_;
+  // remote rack, local dc
+  PerKeyHostMap per_remote_rack_live_hosts_;
+  PerKeyHostMap per_remote_dc_live_hosts_;
   size_t index_;
 
 private:

--- a/src/rack_aware_policy.hpp
+++ b/src/rack_aware_policy.hpp
@@ -31,8 +31,7 @@ namespace datastax { namespace internal { namespace core {
 
 class RackAwarePolicy : public LoadBalancingPolicy {
 public:
-  RackAwarePolicy(const String& local_dc = "", const String &local_rack = "", size_t used_hosts_per_remote_dc = 0,
-                bool skip_remote_dcs_for_local_cl = true);
+  RackAwarePolicy(const String& local_dc = "", const String &local_rack = "");
 
   ~RackAwarePolicy();
 
@@ -51,13 +50,11 @@ public:
   virtual void on_host_up(const Host::Ptr& host);
   virtual void on_host_down(const Address& address);
 
-  virtual bool skip_remote_dcs_for_local_cl() const;
-  virtual size_t used_hosts_per_remote_dc() const;
   virtual const String& local_dc() const;
   virtual const String& local_rack() const;
 
   virtual LoadBalancingPolicy* new_instance() {
-    return new RackAwarePolicy(local_dc_, local_rack_, used_hosts_per_remote_dc_, skip_remote_dcs_for_local_cl_);
+    return new RackAwarePolicy(local_dc_, local_rack_);
   }
 
 private:
@@ -113,8 +110,6 @@ private:
 
   String local_dc_;
   String local_rack_;
-  size_t used_hosts_per_remote_dc_;
-  bool skip_remote_dcs_for_local_cl_;
 
   CopyOnWriteHostVec local_dc_live_hosts_;
   PerDCHostMap per_remote_dc_live_hosts_;

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -170,7 +170,7 @@ RequestProcessor::RequestProcessor(RequestProcessorListener* listener, EventLoop
                                    const Host::Ptr& connected_host, const HostMap& hosts,
                                    const TokenMap::Ptr& token_map,
                                    const RequestProcessorSettings& settings, Random* random,
-                                   const String& local_dc)
+                                   const String& local_dc, const String& local_rack)
     : connection_pool_manager_(connection_pool_manager)
     , listener_(listener ? listener : &nop_request_processor_listener__)
     , event_loop_(event_loop)
@@ -213,7 +213,7 @@ RequestProcessor::RequestProcessor(RequestProcessorListener* listener, EventLoop
   LoadBalancingPolicy::Vec policies = load_balancing_policies();
   for (LoadBalancingPolicy::Vec::const_iterator it = policies.begin(); it != policies.end(); ++it) {
     // Initialize the load balancing policies
-    (*it)->init(connected_host, hosts, random, local_dc);
+    (*it)->init(connected_host, hosts, random, local_dc, local_rack);
     (*it)->register_handles(event_loop_->loop());
   }
 

--- a/src/request_processor.hpp
+++ b/src/request_processor.hpp
@@ -166,12 +166,13 @@ public:
    * @param settings The current settings for the request processor.
    * @param random A RNG for randomizing hosts in the load balancing policies.
    * @param local_dc The local datacenter for initializing the load balancing policies.
+   * @param local_rack The local rack for initializing the load balancing policies.
    */
   RequestProcessor(RequestProcessorListener* listener, EventLoop* event_loop,
                    const ConnectionPoolManager::Ptr& connection_pool_manager,
                    const Host::Ptr& connected_host, const HostMap& hosts,
                    const TokenMap::Ptr& token_map, const RequestProcessorSettings& settings,
-                   Random* random, const String& local_dc);
+                   Random* random, const String& local_dc, const String& local_rack);
 
   /**
    * Close/Terminate the request request processor (thread-safe).

--- a/src/request_processor_initializer.cpp
+++ b/src/request_processor_initializer.cpp
@@ -40,7 +40,7 @@ private:
 
 RequestProcessorInitializer::RequestProcessorInitializer(
     const Host::Ptr& connected_host, ProtocolVersion protocol_version, const HostMap& hosts,
-    const TokenMap::Ptr& token_map, const String& local_dc, const Callback& callback)
+    const TokenMap::Ptr& token_map, const String& local_dc, const String& local_rack, const Callback& callback)
     : event_loop_(NULL)
     , listener_(NULL)
     , metrics_(NULL)
@@ -51,6 +51,7 @@ RequestProcessorInitializer::RequestProcessorInitializer(
     , hosts_(hosts)
     , token_map_(token_map)
     , local_dc_(local_dc)
+    , local_rack_(local_rack)
     , error_code_(REQUEST_PROCESSOR_OK)
     , callback_(callback) {
   uv_mutex_init(&mutex_);
@@ -166,7 +167,7 @@ void RequestProcessorInitializer::on_initialize(ConnectionPoolManagerInitializer
   } else {
     processor_.reset(new RequestProcessor(listener_, event_loop_, initializer->release_manager(),
                                           connected_host_, hosts_, token_map_, settings_, random_,
-                                          local_dc_));
+                                          local_dc_, local_rack_));
 
     int rc = processor_->init(RequestProcessor::Protected());
     if (rc != 0) {

--- a/src/request_processor_initializer.hpp
+++ b/src/request_processor_initializer.hpp
@@ -60,12 +60,13 @@ public:
    * @param hosts A mapping of available hosts in the cluster.
    * @param token_map A token map.
    * @param local_dc The local datacenter for initializing the load balancing policies.
+   * @param local_rack The local datacenter for initializing the load balancing policies.
    * @param callback A callback that is called when the processor is initialized
    * or if an error occurred.
    */
   RequestProcessorInitializer(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                               const HostMap& hosts, const TokenMap::Ptr& token_map,
-                              const String& local_dc, const Callback& callback);
+                              const String& local_dc, const String& local_rack, const Callback& callback);
   ~RequestProcessorInitializer();
 
   /**
@@ -176,6 +177,7 @@ private:
   HostMap hosts_;
   const TokenMap::Ptr token_map_;
   String local_dc_;
+  String local_rack_;
 
   RequestProcessorError error_code_;
   String error_message_;

--- a/src/round_robin_policy.cpp
+++ b/src/round_robin_policy.cpp
@@ -33,7 +33,7 @@ RoundRobinPolicy::RoundRobinPolicy()
 RoundRobinPolicy::~RoundRobinPolicy() { uv_rwlock_destroy(&available_rwlock_); }
 
 void RoundRobinPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                            const String& local_dc) {
+                            const String& local_dc, const String& local_rack) {
   available_.resize(hosts.size());
   std::transform(hosts.begin(), hosts.end(), std::inserter(available_, available_.begin()),
                  GetAddress());

--- a/src/round_robin_policy.hpp
+++ b/src/round_robin_policy.hpp
@@ -31,7 +31,7 @@ public:
   ~RoundRobinPolicy();
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual CassHostDistance distance(const Host::Ptr& host) const;
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -169,6 +169,16 @@ void cass_session_get_speculative_execution_metrics(const CassSession* session,
 
 CassUuid cass_session_get_client_id(CassSession* session) { return session->client_id(); }
 
+cass_uint64_t cass_session_get_inflight_request_count(const CassSession* session) {
+  cass_uint64_t inflight_request_count = 0;
+  const HostMap hosts = session->cluster()->available_hosts();
+  for (HostMap::const_iterator it = hosts.begin(), end = hosts.end(); it != end; ++it) {
+    const Host::Ptr& host = it->second;
+    inflight_request_count += host->inflight_request_count();
+  }
+  return inflight_request_count;
+}
+
 } // extern "C"
 
 static inline bool least_busy_comp(const RequestProcessor::Ptr& a, const RequestProcessor::Ptr& b) {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -195,13 +195,14 @@ public:
   SessionInitializer() { uv_mutex_destroy(&mutex_); }
 
   void initialize(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
-                  const HostMap& hosts, const TokenMap::Ptr& token_map, const String& local_dc) {
+                  const HostMap& hosts, const TokenMap::Ptr& token_map, const String& local_dc,
+		  const String& local_rack) {
     inc_ref();
 
     const size_t thread_count_io = remaining_ = session_->config().thread_count_io();
     for (size_t i = 0; i < thread_count_io; ++i) {
       RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-          connected_host, protocol_version, hosts, token_map, local_dc,
+          connected_host, protocol_version, hosts, token_map, local_dc, local_rack,
           bind_callback(&SessionInitializer::on_initialize, this)));
 
       RequestProcessorSettings settings(session_->config());
@@ -360,7 +361,7 @@ void Session::join() {
 
 void Session::on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                          const HostMap& hosts, const TokenMap::Ptr& token_map,
-                         const String& local_dc) {
+                         const String& local_dc, const String& local_rack) {
   int rc = 0;
 
   if (hosts.empty()) {
@@ -394,7 +395,7 @@ void Session::on_connect(const Host::Ptr& connected_host, ProtocolVersion protoc
   request_processor_count_ = 0;
   is_closing_ = false;
   SessionInitializer::Ptr initializer(new SessionInitializer(this));
-  initializer->initialize(connected_host, protocol_version, hosts, token_map, local_dc);
+  initializer->initialize(connected_host, protocol_version, hosts, token_map, local_dc, local_rack);
 }
 
 void Session::on_close() {

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -54,7 +54,7 @@ private:
 
   virtual void on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                           const HostMap& hosts, const TokenMap::Ptr& token_map,
-                          const String& local_dc);
+                          const String& local_dc, const String& local_rack);
 
   virtual void on_close();
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -160,7 +160,7 @@ void SessionBase::notify_closed() {
 
 void SessionBase::on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                              const HostMap& hosts, const TokenMap::Ptr& token_map,
-                             const String& local_dc) {
+                             const String& local_dc, const String& local_rack) {
   notify_connected();
 }
 
@@ -200,7 +200,7 @@ void SessionBase::on_initialize(ClusterConnector* connector) {
     }
 
     on_connect(cluster_->connected_host(), cluster_->protocol_version(),
-               cluster_->available_hosts(), cluster_->token_map(), cluster_->local_dc());
+               cluster_->available_hosts(), cluster_->token_map(), cluster_->local_dc(), cluster_->local_rack());
   } else {
     assert(!connector->is_canceled() && "Cluster connection process canceled");
     switch (connector->error_code()) {

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -117,7 +117,7 @@ protected:
    */
   virtual void on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                           const HostMap& hosts, const TokenMap::Ptr& token_map,
-                          const String& local_dc);
+                          const String& local_dc, const String& local_rack);
 
   /**
    * A callback called after the control connection fails to connect. By default

--- a/src/token_aware_policy.cpp
+++ b/src/token_aware_policy.cpp
@@ -105,10 +105,19 @@ Host::Ptr TokenAwarePolicy::TokenAwareQueryPlan::compute_next() {
     }
   }
 
+  while (remaining_remote2_ > 0) {
+    --remaining_remote2_;
+    const Host::Ptr& host((*replicas_)[index_++ % replicas_->size()]);
+    if (child_policy_->is_host_up(host->address()) &&
+        child_policy_->distance(host) == CASS_HOST_DISTANCE_REMOTE2) {
+      return host;
+    }
+  }
+
   Host::Ptr host;
   while ((host = child_plan_->compute_next())) {
     if (!contains(replicas_, host->address()) ||
-        child_policy_->distance(host) > CASS_HOST_DISTANCE_REMOTE) {
+        child_policy_->distance(host) > CASS_HOST_DISTANCE_REMOTE2) {
       return host;
     }
   }

--- a/src/token_aware_policy.cpp
+++ b/src/token_aware_policy.cpp
@@ -37,7 +37,7 @@ static inline bool contains(const CopyOnWriteHostVec& replicas, const Address& a
 }
 
 void TokenAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                            const String& local_dc) {
+                            const String& local_dc, const String& local_rack) {
   if (random != NULL) {
     if (shuffle_replicas_) {
       // Store random so that it can be used to shuffle replicas.
@@ -48,7 +48,7 @@ void TokenAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& host
       index_ = random->next(std::max(static_cast<size_t>(1), hosts.size()));
     }
   }
-  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc);
+  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc, local_rack);
 }
 
 QueryPlan* TokenAwarePolicy::new_query_plan(const String& keyspace, RequestHandler* request_handler,

--- a/src/token_aware_policy.hpp
+++ b/src/token_aware_policy.hpp
@@ -53,7 +53,8 @@ private:
         , child_plan_(child_plan)
         , replicas_(replicas)
         , index_(start_index)
-        , remaining_(replicas->size()) {}
+        , remaining_local_(replicas->size())
+        , remaining_remote_(replicas->size()) {}
 
     Host::Ptr compute_next();
 
@@ -62,7 +63,8 @@ private:
     ScopedPtr<QueryPlan> child_plan_;
     CopyOnWriteHostVec replicas_;
     size_t index_;
-    size_t remaining_;
+    size_t remaining_local_;
+    size_t remaining_remote_;
   };
 
   Random* random_;

--- a/src/token_aware_policy.hpp
+++ b/src/token_aware_policy.hpp
@@ -35,7 +35,7 @@ public:
   virtual ~TokenAwarePolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual QueryPlan* new_query_plan(const String& keyspace, RequestHandler* request_handler,
                                     const TokenMap* token_map);

--- a/src/token_aware_policy.hpp
+++ b/src/token_aware_policy.hpp
@@ -54,7 +54,8 @@ private:
         , replicas_(replicas)
         , index_(start_index)
         , remaining_local_(replicas->size())
-        , remaining_remote_(replicas->size()) {}
+        , remaining_remote_(replicas->size())
+        , remaining_remote2_(replicas->size()) {}
 
     Host::Ptr compute_next();
 
@@ -65,6 +66,7 @@ private:
     size_t index_;
     size_t remaining_local_;
     size_t remaining_remote_;
+    size_t remaining_remote2_;
   };
 
   Random* random_;


### PR DESCRIPTION
We need to prefer local rack as there are higher network costs when associated with nodes in remote rack.

This is initial version, some things are still missing:

* no tests yet
* fallback to racks in local DC is not implemented yet (i.e. this version can connect to remote DC even if there is another rack in the local DC that we haven't tried yet)