### PR TITLE
Add rack-aware load balancing policy

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2214,6 +2214,50 @@ cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster,
                                          cass_bool_t allow_remote_dcs_for_local_cl);
 
 /**
+ * Configures the cluster to use Rack-aware load balancing.
+ * For each query, all live nodes in a primary 'local' rack are tried first,
+ * followed by nodes from local DC and then nodes from other DCs.
+ *
+ * With empty local_rack and local_dc,  default local_dc and local_rack
+ * is chosen from the first connected contact point,
+ * and no remote hosts are considered in query plans.
+ * If relying on this mechanism, be sure to use only contact
+ * points from the local rack.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc The primary data center to try first
+ * @param[in] local_rack The primary rack to try first
+ * @return CASS_OK if successful, otherwise an error occurred
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware(CassCluster* cluster,
+                                       const char* local_dc,
+                                       const char* local_rack);
+
+
+/**
+ * Same as cass_cluster_set_load_balance_rack_aware(), but with lengths for string
+ * parameters.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc
+ * @param[in] local_dc_length
+ * @return same as cass_cluster_set_load_balance_dc_aware()
+ *
+ * @see cass_cluster_set_load_balance_dc_aware()
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster,
+                                         const char* local_dc,
+                                         size_t local_dc_length,
+                                         const char* local_rack,
+                                         size_t local_rack_length);
+
+/**
  * Configures the cluster to use token-aware request routing or not.
  *
  * <b>Important:</b> Token-aware routing depends on keyspace metadata.

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -18,6 +18,7 @@
 
 #include "constants.hpp"
 #include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 #include "external.hpp"
 #include "logger.hpp"
 #include "resolver.hpp"
@@ -240,6 +241,7 @@ Cluster::Cluster(const ControlConnection::Ptr& connection, ClusterListener* list
                  const ControlConnectionSchema& schema,
                  const LoadBalancingPolicy::Ptr& load_balancing_policy,
                  const LoadBalancingPolicy::Vec& load_balancing_policies, const String& local_dc,
+		 const String& local_rack,
                  const StringMultimap& supported_options, const ClusterSettings& settings)
     : connection_(connection)
     , listener_(listener ? listener : &nop_cluster_listener__)
@@ -251,6 +253,7 @@ Cluster::Cluster(const ControlConnection::Ptr& connection, ClusterListener* list
     , connected_host_(connected_host)
     , hosts_(hosts)
     , local_dc_(local_dc)
+    , local_rack_(local_rack)
     , supported_options_(supported_options)
     , is_recording_events_(settings.disable_events_on_startup) {
   static const auto optimized_msg = "===== Using optimized driver!!! =====\n";

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -257,6 +257,7 @@ public:
    * determining the next control connection host.
    * @param load_balancing_policies
    * @param local_dc The local datacenter determined by the metadata service for initializing the
+   * @param local_rack The local rack determined by the metadata service for initializing the
    * load balancing policies.
    * @param supported_options Supported options discovered during control connection.
    * @param settings The control connection settings to use for reconnecting the
@@ -267,6 +268,7 @@ public:
           const ControlConnectionSchema& schema,
           const LoadBalancingPolicy::Ptr& load_balancing_policy,
           const LoadBalancingPolicy::Vec& load_balancing_policies, const String& local_dc,
+	  const String& local_rack,
           const StringMultimap& supported_options, const ClusterSettings& settings);
 
   /**
@@ -361,6 +363,7 @@ public:
   const Host::Ptr& connected_host() const { return connected_host_; }
   const TokenMap::Ptr& token_map() const { return token_map_; }
   const String& local_dc() const { return local_dc_; }
+  const String& local_rack() const { return local_rack_; }
   const VersionNumber& dse_server_version() const { return connection_->dse_server_version(); }
   const StringMultimap& supported_options() const { return supported_options_; }
   const ShardPortCalculator* shard_port_calculator() const { return shard_port_calculator_.get(); }
@@ -449,6 +452,7 @@ private:
   PreparedMetadata prepared_metadata_;
   TokenMap::Ptr token_map_;
   String local_dc_;
+  String local_rack_;
   StringMultimap supported_options_;
   Timer timer_;
   bool is_recording_events_;

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -301,6 +301,27 @@ CassError cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster, const c
   return CASS_OK;
 }
 
+CassError cass_cluster_set_load_balance_rack_aware(CassCluster* cluster, const char* local_dc,
+                                                 const char* local_rack) {
+  if (local_dc == NULL || local_rack == NULL) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  return cass_cluster_set_load_balance_rack_aware_n(cluster, local_dc, SAFE_STRLEN(local_dc),
+                                                  local_rack, SAFE_STRLEN(local_rack));
+}
+
+CassError cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster, const char* local_dc,
+                                                   size_t local_dc_length,
+                                                   const char* local_rack,
+                                                   size_t local_rack_length) {
+  if (local_dc == NULL || local_dc_length == 0 || local_rack == NULL || local_rack_length == 0) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  cluster->config().set_load_balancing_policy(new RackAwarePolicy(
+      String(local_dc, local_dc_length), String(local_rack, local_rack_length)));
+  return CASS_OK;
+}
+
 void cass_cluster_set_token_aware_routing(CassCluster* cluster, cass_bool_t enabled) {
   cluster->config().set_token_aware_routing(enabled == cass_true);
 }

--- a/src/cluster_connector.hpp
+++ b/src/cluster_connector.hpp
@@ -169,6 +169,7 @@ private:
   Random* random_;
   Metrics* metrics_;
   String local_dc_;
+  String local_rack_;
   ClusterSettings settings_;
 
   Callback callback_;

--- a/src/cluster_metadata_resolver.hpp
+++ b/src/cluster_metadata_resolver.hpp
@@ -48,6 +48,7 @@ public:
 
   const AddressVec& resolved_contact_points() const { return resolved_contact_points_; }
   const String& local_dc() const { return local_dc_; }
+  const String& local_rack() const { return local_rack_; }
 
 protected:
   virtual void internal_resolve(uv_loop_t* loop, const AddressVec& contact_points) = 0;
@@ -57,6 +58,7 @@ protected:
 protected:
   AddressVec resolved_contact_points_;
   String local_dc_;
+  String local_rack_;
   Callback callback_;
 };
 

--- a/src/execution_profile.hpp
+++ b/src/execution_profile.hpp
@@ -23,6 +23,7 @@
 #include "cassandra.h"
 #include "constants.hpp"
 #include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 #include "dense_hash_map.hpp"
 #include "latency_aware_policy.hpp"
 #include "speculative_execution.hpp"

--- a/src/latency_aware_policy.cpp
+++ b/src/latency_aware_policy.cpp
@@ -27,13 +27,13 @@ using namespace datastax::internal;
 using namespace datastax::internal::core;
 
 void LatencyAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                              const String& local_dc) {
+                              const String& local_dc, const String& local_rack) {
   hosts_->reserve(hosts.size());
   std::transform(hosts.begin(), hosts.end(), std::back_inserter(*hosts_), GetHost());
   for (HostMap::const_iterator i = hosts.begin(), end = hosts.end(); i != end; ++i) {
     i->second->enable_latency_tracking(settings_.scale_ns, settings_.min_measured);
   }
-  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc);
+  ChainedLoadBalancingPolicy::init(connected_host, hosts, random, local_dc, local_rack);
 }
 
 void LatencyAwarePolicy::register_handles(uv_loop_t* loop) { start_timer(loop); }

--- a/src/latency_aware_policy.hpp
+++ b/src/latency_aware_policy.hpp
@@ -51,7 +51,7 @@ public:
   virtual ~LatencyAwarePolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual void register_handles(uv_loop_t* loop);
   virtual void close_handles();

--- a/src/list_policy.cpp
+++ b/src/list_policy.cpp
@@ -23,7 +23,7 @@ using namespace datastax::internal;
 using namespace datastax::internal::core;
 
 void ListPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                      const String& local_dc) {
+                      const String& local_dc, const String& local_rack) {
   HostMap valid_hosts;
   for (HostMap::const_iterator i = hosts.begin(), end = hosts.end(); i != end; ++i) {
     const Host::Ptr& host = i->second;
@@ -36,7 +36,7 @@ void ListPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Ran
     LOG_ERROR("No valid hosts available for list policy");
   }
 
-  ChainedLoadBalancingPolicy::init(connected_host, valid_hosts, random, local_dc);
+  ChainedLoadBalancingPolicy::init(connected_host, valid_hosts, random, local_dc, local_rack);
 }
 
 CassHostDistance ListPolicy::distance(const Host::Ptr& host) const {

--- a/src/list_policy.hpp
+++ b/src/list_policy.hpp
@@ -31,7 +31,7 @@ public:
   virtual ~ListPolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual CassHostDistance distance(const Host::Ptr& host) const;
 

--- a/src/rack_aware_policy.cpp
+++ b/src/rack_aware_policy.cpp
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-#include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 
 #include "logger.hpp"
 #include "request_handler.hpp"
@@ -26,23 +26,17 @@ using namespace datastax;
 using namespace datastax::internal;
 using namespace datastax::internal::core;
 
-DCAwarePolicy::DCAwarePolicy(const String& local_dc, size_t used_hosts_per_remote_dc,
-                             bool skip_remote_dcs_for_local_cl)
+RackAwarePolicy::RackAwarePolicy(const String& local_dc, const String& local_rack)
     : local_dc_(local_dc)
-    , used_hosts_per_remote_dc_(used_hosts_per_remote_dc)
-    , skip_remote_dcs_for_local_cl_(skip_remote_dcs_for_local_cl)
-    , local_dc_live_hosts_(new HostVec())
+    , local_rack_(local_rack)
+    , local_rack_live_hosts_(new HostVec())
     , index_(0) {
   uv_rwlock_init(&available_rwlock_);
-  if (used_hosts_per_remote_dc_ > 0 || !skip_remote_dcs_for_local_cl) {
-    LOG_WARN("Remote multi-dc settings have been deprecated and will be removed"
-             " in the next major release");
-  }
 }
 
-DCAwarePolicy::~DCAwarePolicy() { uv_rwlock_destroy(&available_rwlock_); }
+RackAwarePolicy::~RackAwarePolicy() { uv_rwlock_destroy(&available_rwlock_); }
 
-void DCAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
+void RackAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
                          const String& local_dc, const String& local_rack) {
   if (local_dc_.empty()) { // Only override if no local DC was specified.
     local_dc_ = local_dc;
@@ -53,6 +47,17 @@ void DCAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, 
              "(if this is incorrect, please provide the correct data center)",
              connected_host->dc().c_str());
     local_dc_ = connected_host->dc();
+  }
+
+  if (local_rack_.empty()) { // Only override if no local rack was specified.
+    local_rack_ = local_rack;
+  }
+
+  if (local_rack_.empty() && connected_host && !connected_host->rack().empty()) {
+    LOG_INFO("Using '%s' for the local rack "
+             "(if this is incorrect, please provide the correct rack)",
+             connected_host->rack().c_str());
+    local_rack_ = connected_host->rack();
   }
 
   available_.resize(hosts.size());
@@ -67,71 +72,94 @@ void DCAwarePolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, 
   }
 }
 
-CassHostDistance DCAwarePolicy::distance(const Host::Ptr& host) const {
-  if (local_dc_.empty() || host->dc() == local_dc_) {
+CassHostDistance RackAwarePolicy::distance(const Host::Ptr& host) const {
+  if (local_dc_.empty() || local_rack_.empty() || (host->dc() == local_dc_ && host->rack() == local_rack_)) {
     return CASS_HOST_DISTANCE_LOCAL;
   }
 
+  if (host->dc() == local_dc_) {
+    const CopyOnWriteHostVec& hosts = per_remote_rack_live_hosts_.get_hosts(host->rack());
+    size_t num_hosts = hosts->size();
+    for (size_t i = 0; i < num_hosts; ++i) {
+      if ((*hosts)[i]->address() == host->address()) {
+        return CASS_HOST_DISTANCE_REMOTE;
+      }
+    }
+  }
+
   const CopyOnWriteHostVec& hosts = per_remote_dc_live_hosts_.get_hosts(host->dc());
-  size_t num_hosts = std::min(hosts->size(), used_hosts_per_remote_dc_);
+  size_t num_hosts = hosts->size();
   for (size_t i = 0; i < num_hosts; ++i) {
     if ((*hosts)[i]->address() == host->address()) {
-      return CASS_HOST_DISTANCE_REMOTE;
+      return CASS_HOST_DISTANCE_REMOTE2;
     }
   }
 
   return CASS_HOST_DISTANCE_IGNORE;
 }
 
-QueryPlan* DCAwarePolicy::new_query_plan(const String& keyspace, RequestHandler* request_handler,
+QueryPlan* RackAwarePolicy::new_query_plan(const String& keyspace, RequestHandler* request_handler,
                                          const TokenMap* token_map) {
   CassConsistency cl =
       request_handler != NULL ? request_handler->consistency() : CASS_DEFAULT_CONSISTENCY;
-  return new DCAwareQueryPlan(this, cl, index_++);
+  return new RackAwareQueryPlan(this, cl, index_++);
 }
 
-bool DCAwarePolicy::is_host_up(const Address& address) const {
+bool RackAwarePolicy::is_host_up(const Address& address) const {
   ScopedReadLock rl(&available_rwlock_);
   return available_.count(address) > 0;
 }
 
-void DCAwarePolicy::on_host_added(const Host::Ptr& host) {
+void RackAwarePolicy::on_host_added(const Host::Ptr& host) {
   const String& dc = host->dc();
+  const String& rack = host->rack();
   if (local_dc_.empty() && !dc.empty()) {
     LOG_INFO("Using '%s' for local data center "
              "(if this is incorrect, please provide the correct data center)",
              host->dc().c_str());
     local_dc_ = dc;
   }
+  if (local_rack_.empty() && !rack.empty()) {
+    LOG_INFO("Using '%s' for local data center "
+             "(if this is incorrect, please provide the correct data center)",
+             host->rack().c_str());
+    local_rack_ = rack;
+  }
 
-  if (dc == local_dc_) {
-    add_host(local_dc_live_hosts_, host);
+  if (dc == local_dc_ && rack == local_rack_) {
+    add_host(local_rack_live_hosts_, host);
+  } else if (dc == local_dc_) {
+    per_remote_rack_live_hosts_.add_host_to_key(rack, host);
   } else {
-    per_remote_dc_live_hosts_.add_host_to_dc(dc, host);
+    per_remote_dc_live_hosts_.add_host_to_key(dc, host);
   }
 }
 
-void DCAwarePolicy::on_host_removed(const Host::Ptr& host) {
+void RackAwarePolicy::on_host_removed(const Host::Ptr& host) {
   const String& dc = host->dc();
-  if (dc == local_dc_) {
-    remove_host(local_dc_live_hosts_, host);
+  const String& rack = host->rack();
+  if (dc == local_dc_ && rack == local_rack_) {
+    remove_host(local_rack_live_hosts_, host);
+  } else if (dc == local_dc_) {
+    per_remote_rack_live_hosts_.remove_host_from_key(host->rack(), host);
   } else {
-    per_remote_dc_live_hosts_.remove_host_from_dc(host->dc(), host);
+    per_remote_dc_live_hosts_.remove_host_from_key(host->dc(), host);
   }
 
   ScopedWriteLock wl(&available_rwlock_);
   available_.erase(host->address());
 }
 
-void DCAwarePolicy::on_host_up(const Host::Ptr& host) {
+void RackAwarePolicy::on_host_up(const Host::Ptr& host) {
   on_host_added(host);
 
   ScopedWriteLock wl(&available_rwlock_);
   available_.insert(host->address());
 }
 
-void DCAwarePolicy::on_host_down(const Address& address) {
-  if (!remove_host(local_dc_live_hosts_, address) &&
+void RackAwarePolicy::on_host_down(const Address& address) {
+  if (!remove_host(local_rack_live_hosts_, address) &&
+      !per_remote_rack_live_hosts_.remove_host(address) &&
       !per_remote_dc_live_hosts_.remove_host(address)) {
     LOG_DEBUG("Attempted to mark host %s as DOWN, but it doesn't exist",
               address.to_string().c_str());
@@ -141,42 +169,37 @@ void DCAwarePolicy::on_host_down(const Address& address) {
   available_.erase(address);
 }
 
-bool DCAwarePolicy::skip_remote_dcs_for_local_cl() const {
-  ScopedReadLock rl(&available_rwlock_);
-  return skip_remote_dcs_for_local_cl_;
-}
-
-size_t DCAwarePolicy::used_hosts_per_remote_dc() const {
-  ScopedReadLock rl(&available_rwlock_);
-  return used_hosts_per_remote_dc_;
-}
-
-const String& DCAwarePolicy::local_dc() const {
+const String& RackAwarePolicy::local_dc() const {
   ScopedReadLock rl(&available_rwlock_);
   return local_dc_;
 }
 
-void DCAwarePolicy::PerDCHostMap::add_host_to_dc(const String& dc, const Host::Ptr& host) {
+const String& RackAwarePolicy::local_rack() const {
+  ScopedReadLock rl(&available_rwlock_);
+  return local_rack_;
+}
+
+void RackAwarePolicy::PerKeyHostMap::add_host_to_key(const String& key, const Host::Ptr& host) {
   ScopedWriteLock wl(&rwlock_);
-  Map::iterator i = map_.find(dc);
+  Map::iterator i = map_.find(key);
   if (i == map_.end()) {
     CopyOnWriteHostVec hosts(new HostVec());
     hosts->push_back(host);
-    map_.insert(Map::value_type(dc, hosts));
+    map_.insert(Map::value_type(key, hosts));
   } else {
     add_host(i->second, host);
   }
 }
 
-void DCAwarePolicy::PerDCHostMap::remove_host_from_dc(const String& dc, const Host::Ptr& host) {
+void RackAwarePolicy::PerKeyHostMap::remove_host_from_key(const String& key, const Host::Ptr& host) {
   ScopedWriteLock wl(&rwlock_);
-  Map::iterator i = map_.find(dc);
+  Map::iterator i = map_.find(key);
   if (i != map_.end()) {
     core::remove_host(i->second, host);
   }
 }
 
-bool DCAwarePolicy::PerDCHostMap::remove_host(const Address& address) {
+bool RackAwarePolicy::PerKeyHostMap::remove_host(const Address& address) {
   ScopedWriteLock wl(&rwlock_);
   for (Map::iterator i = map_.begin(), end = map_.end(); i != end; ++i) {
     if (core::remove_host(i->second, address)) {
@@ -186,7 +209,7 @@ bool DCAwarePolicy::PerDCHostMap::remove_host(const Address& address) {
   return false;
 }
 
-const CopyOnWriteHostVec& DCAwarePolicy::PerDCHostMap::get_hosts(const String& dc) const {
+const CopyOnWriteHostVec& RackAwarePolicy::PerKeyHostMap::get_hosts(const String& dc) const {
   ScopedReadLock rl(&rwlock_);
   Map::const_iterator i = map_.find(dc);
   if (i == map_.end()) return no_hosts_;
@@ -194,10 +217,10 @@ const CopyOnWriteHostVec& DCAwarePolicy::PerDCHostMap::get_hosts(const String& d
   return i->second;
 }
 
-void DCAwarePolicy::PerDCHostMap::copy_dcs(KeySet* dcs) const {
+void RackAwarePolicy::PerKeyHostMap::copy_keys(KeySet* keys) const {
   ScopedReadLock rl(&rwlock_);
   for (Map::const_iterator i = map_.begin(), end = map_.end(); i != end; ++i) {
-    dcs->insert(i->first);
+    keys->insert(i->first);
   }
 }
 
@@ -207,23 +230,18 @@ static const Host::Ptr& get_next_host(const CopyOnWriteHostVec& hosts, size_t in
   return (*hosts)[index % hosts->size()];
 }
 
-static const Host::Ptr& get_next_host_bounded(const CopyOnWriteHostVec& hosts, size_t index,
-                                              size_t bound) {
-  return (*hosts)[index % std::min(hosts->size(), bound)];
-}
-
 static size_t get_hosts_size(const CopyOnWriteHostVec& hosts) { return hosts->size(); }
 
-DCAwarePolicy::DCAwareQueryPlan::DCAwareQueryPlan(const DCAwarePolicy* policy, CassConsistency cl,
+RackAwarePolicy::RackAwareQueryPlan::RackAwareQueryPlan(const RackAwarePolicy* policy, CassConsistency cl,
                                                   size_t start_index)
     : policy_(policy)
     , cl_(cl)
-    , hosts_(policy_->local_dc_live_hosts_)
+    , hosts_(policy_->local_rack_live_hosts_)
     , local_remaining_(get_hosts_size(hosts_))
     , remote_remaining_(0)
     , index_(start_index) {}
 
-Host::Ptr DCAwarePolicy::DCAwareQueryPlan::compute_next() {
+Host::Ptr RackAwarePolicy::RackAwareQueryPlan::compute_next() {
   while (local_remaining_ > 0) {
     --local_remaining_;
     const Host::Ptr& host(get_next_host(hosts_, index_++));
@@ -232,20 +250,46 @@ Host::Ptr DCAwarePolicy::DCAwareQueryPlan::compute_next() {
     }
   }
 
-  if (policy_->skip_remote_dcs_for_local_cl_ && is_dc_local(cl_)) {
-    return Host::Ptr();
-  }
-
-  if (!remote_dcs_) {
-    remote_dcs_.reset(new PerDCHostMap::KeySet());
-    policy_->per_remote_dc_live_hosts_.copy_dcs(remote_dcs_.get());
+  if (!remote_racks_) {
+    remote_racks_.reset(new PerKeyHostMap::KeySet());
+    policy_->per_remote_rack_live_hosts_.copy_keys(remote_racks_.get());
   }
 
   while (true) {
     while (remote_remaining_ > 0) {
       --remote_remaining_;
       const Host::Ptr& host(
-          get_next_host_bounded(hosts_, index_++, policy_->used_hosts_per_remote_dc_));
+          get_next_host(hosts_, index_++));
+      if (policy_->is_host_up(host->address())) {
+        return host;
+      }
+    }
+
+    if (remote_racks_->empty()) {
+      break;
+    }
+
+    PerKeyHostMap::KeySet::iterator i = remote_racks_->begin();
+    hosts_ = policy_->per_remote_rack_live_hosts_.get_hosts(*i);
+    remote_remaining_ = get_hosts_size(hosts_);
+    remote_racks_->erase(i);
+  }
+
+  // Skip remote DCs for LOCAL_ consistency levels.
+  if (is_dc_local(cl_)) {
+    return Host::Ptr();
+  }
+
+  if (!remote_dcs_) {
+    remote_dcs_.reset(new PerKeyHostMap::KeySet());
+    policy_->per_remote_dc_live_hosts_.copy_keys(remote_dcs_.get());
+  }
+
+  while (true) {
+    while (remote_remaining_ > 0) {
+      --remote_remaining_;
+      const Host::Ptr& host(
+          get_next_host(hosts_, index_++));
       if (policy_->is_host_up(host->address())) {
         return host;
       }
@@ -255,9 +299,9 @@ Host::Ptr DCAwarePolicy::DCAwareQueryPlan::compute_next() {
       break;
     }
 
-    PerDCHostMap::KeySet::iterator i = remote_dcs_->begin();
+    PerKeyHostMap::KeySet::iterator i = remote_dcs_->begin();
     hosts_ = policy_->per_remote_dc_live_hosts_.get_hosts(*i);
-    remote_remaining_ = std::min(get_hosts_size(hosts_), policy_->used_hosts_per_remote_dc_);
+    remote_remaining_ = get_hosts_size(hosts_);
     remote_dcs_->erase(i);
   }
 

--- a/src/rack_aware_policy.hpp
+++ b/src/rack_aware_policy.hpp
@@ -14,8 +14,8 @@
   limitations under the License.
 */
 
-#ifndef DATASTAX_INTERNAL_DC_AWARE_POLICY_HPP
-#define DATASTAX_INTERNAL_DC_AWARE_POLICY_HPP
+#ifndef DATASTAX_INTERNAL_RACK_AWARE_POLICY_HPP
+#define DATASTAX_INTERNAL_RACK_AWARE_POLICY_HPP
 
 #include "host.hpp"
 #include "load_balancing.hpp"
@@ -29,12 +29,11 @@
 
 namespace datastax { namespace internal { namespace core {
 
-class DCAwarePolicy : public LoadBalancingPolicy {
+class RackAwarePolicy : public LoadBalancingPolicy {
 public:
-  DCAwarePolicy(const String& local_dc = "", size_t used_hosts_per_remote_dc = 0,
-                bool skip_remote_dcs_for_local_cl = true);
+  RackAwarePolicy(const String& local_dc = "", const String &local_rack = "");
 
-  ~DCAwarePolicy();
+  ~RackAwarePolicy();
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
                     const String& local_dc, const String& local_rack);
@@ -51,31 +50,30 @@ public:
   virtual void on_host_up(const Host::Ptr& host);
   virtual void on_host_down(const Address& address);
 
-  virtual bool skip_remote_dcs_for_local_cl() const;
-  virtual size_t used_hosts_per_remote_dc() const;
   virtual const String& local_dc() const;
+  virtual const String& local_rack() const;
 
   virtual LoadBalancingPolicy* new_instance() {
-    return new DCAwarePolicy(local_dc_, used_hosts_per_remote_dc_, skip_remote_dcs_for_local_cl_);
+    return new RackAwarePolicy(local_dc_, local_rack_);
   }
 
 private:
-  class PerDCHostMap {
+  class PerKeyHostMap {
   public:
     typedef internal::Map<String, CopyOnWriteHostVec> Map;
     typedef Set<String> KeySet;
 
-    PerDCHostMap()
+    PerKeyHostMap()
         : no_hosts_(new HostVec()) {
       uv_rwlock_init(&rwlock_);
     }
-    ~PerDCHostMap() { uv_rwlock_destroy(&rwlock_); }
+    ~PerKeyHostMap() { uv_rwlock_destroy(&rwlock_); }
 
-    void add_host_to_dc(const String& dc, const Host::Ptr& host);
-    void remove_host_from_dc(const String& dc, const Host::Ptr& host);
+    void add_host_to_key(const String& key, const Host::Ptr& host);
+    void remove_host_from_key(const String& key, const Host::Ptr& host);
     bool remove_host(const Address& address);
-    const CopyOnWriteHostVec& get_hosts(const String& dc) const;
-    void copy_dcs(KeySet* dcs) const;
+    const CopyOnWriteHostVec& get_hosts(const String& key) const;
+    void copy_keys(KeySet* keys) const;
 
   private:
     Map map_;
@@ -83,24 +81,25 @@ private:
     const CopyOnWriteHostVec no_hosts_;
 
   private:
-    DISALLOW_COPY_AND_ASSIGN(PerDCHostMap);
+    DISALLOW_COPY_AND_ASSIGN(PerKeyHostMap);
   };
 
   const CopyOnWriteHostVec& get_local_dc_hosts() const;
-  void get_remote_dcs(PerDCHostMap::KeySet* remote_dcs) const;
+  void get_remote_dcs(PerKeyHostMap::KeySet* remote_dcs) const;
 
 public:
-  class DCAwareQueryPlan : public QueryPlan {
+  class RackAwareQueryPlan : public QueryPlan {
   public:
-    DCAwareQueryPlan(const DCAwarePolicy* policy, CassConsistency cl, size_t start_index);
+    RackAwareQueryPlan(const RackAwarePolicy* policy, CassConsistency cl, size_t start_index);
 
     virtual Host::Ptr compute_next();
 
   private:
-    const DCAwarePolicy* policy_;
+    const RackAwarePolicy* policy_;
     CassConsistency cl_;
     CopyOnWriteHostVec hosts_;
-    ScopedPtr<PerDCHostMap::KeySet> remote_dcs_;
+    ScopedPtr<PerKeyHostMap::KeySet> remote_racks_;
+    ScopedPtr<PerKeyHostMap::KeySet> remote_dcs_;
     size_t local_remaining_;
     size_t remote_remaining_;
     size_t index_;
@@ -111,15 +110,16 @@ private:
   AddressSet available_;
 
   String local_dc_;
-  size_t used_hosts_per_remote_dc_;
-  bool skip_remote_dcs_for_local_cl_;
+  String local_rack_;
 
-  CopyOnWriteHostVec local_dc_live_hosts_;
-  PerDCHostMap per_remote_dc_live_hosts_;
+  CopyOnWriteHostVec local_rack_live_hosts_;
+  // remote rack, local dc
+  PerKeyHostMap per_remote_rack_live_hosts_;
+  PerKeyHostMap per_remote_dc_live_hosts_;
   size_t index_;
 
 private:
-  DISALLOW_COPY_AND_ASSIGN(DCAwarePolicy);
+  DISALLOW_COPY_AND_ASSIGN(RackAwarePolicy);
 };
 
 }}} // namespace datastax::internal::core

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -170,7 +170,7 @@ RequestProcessor::RequestProcessor(RequestProcessorListener* listener, EventLoop
                                    const Host::Ptr& connected_host, const HostMap& hosts,
                                    const TokenMap::Ptr& token_map,
                                    const RequestProcessorSettings& settings, Random* random,
-                                   const String& local_dc)
+                                   const String& local_dc, const String& local_rack)
     : connection_pool_manager_(connection_pool_manager)
     , listener_(listener ? listener : &nop_request_processor_listener__)
     , event_loop_(event_loop)
@@ -213,7 +213,7 @@ RequestProcessor::RequestProcessor(RequestProcessorListener* listener, EventLoop
   LoadBalancingPolicy::Vec policies = load_balancing_policies();
   for (LoadBalancingPolicy::Vec::const_iterator it = policies.begin(); it != policies.end(); ++it) {
     // Initialize the load balancing policies
-    (*it)->init(connected_host, hosts, random, local_dc);
+    (*it)->init(connected_host, hosts, random, local_dc, local_rack);
     (*it)->register_handles(event_loop_->loop());
   }
 

--- a/src/request_processor.hpp
+++ b/src/request_processor.hpp
@@ -166,12 +166,13 @@ public:
    * @param settings The current settings for the request processor.
    * @param random A RNG for randomizing hosts in the load balancing policies.
    * @param local_dc The local datacenter for initializing the load balancing policies.
+   * @param local_rack The local rack for initializing the load balancing policies.
    */
   RequestProcessor(RequestProcessorListener* listener, EventLoop* event_loop,
                    const ConnectionPoolManager::Ptr& connection_pool_manager,
                    const Host::Ptr& connected_host, const HostMap& hosts,
                    const TokenMap::Ptr& token_map, const RequestProcessorSettings& settings,
-                   Random* random, const String& local_dc);
+                   Random* random, const String& local_dc, const String& local_rack);
 
   /**
    * Close/Terminate the request request processor (thread-safe).

--- a/src/request_processor_initializer.cpp
+++ b/src/request_processor_initializer.cpp
@@ -40,7 +40,7 @@ private:
 
 RequestProcessorInitializer::RequestProcessorInitializer(
     const Host::Ptr& connected_host, ProtocolVersion protocol_version, const HostMap& hosts,
-    const TokenMap::Ptr& token_map, const String& local_dc, const Callback& callback)
+    const TokenMap::Ptr& token_map, const String& local_dc, const String& local_rack, const Callback& callback)
     : event_loop_(NULL)
     , listener_(NULL)
     , metrics_(NULL)
@@ -51,6 +51,7 @@ RequestProcessorInitializer::RequestProcessorInitializer(
     , hosts_(hosts)
     , token_map_(token_map)
     , local_dc_(local_dc)
+    , local_rack_(local_rack)
     , error_code_(REQUEST_PROCESSOR_OK)
     , callback_(callback) {
   uv_mutex_init(&mutex_);
@@ -166,7 +167,7 @@ void RequestProcessorInitializer::on_initialize(ConnectionPoolManagerInitializer
   } else {
     processor_.reset(new RequestProcessor(listener_, event_loop_, initializer->release_manager(),
                                           connected_host_, hosts_, token_map_, settings_, random_,
-                                          local_dc_));
+                                          local_dc_, local_rack_));
 
     int rc = processor_->init(RequestProcessor::Protected());
     if (rc != 0) {

--- a/src/request_processor_initializer.hpp
+++ b/src/request_processor_initializer.hpp
@@ -60,12 +60,13 @@ public:
    * @param hosts A mapping of available hosts in the cluster.
    * @param token_map A token map.
    * @param local_dc The local datacenter for initializing the load balancing policies.
+   * @param local_rack The local datacenter for initializing the load balancing policies.
    * @param callback A callback that is called when the processor is initialized
    * or if an error occurred.
    */
   RequestProcessorInitializer(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                               const HostMap& hosts, const TokenMap::Ptr& token_map,
-                              const String& local_dc, const Callback& callback);
+                              const String& local_dc, const String& local_rack, const Callback& callback);
   ~RequestProcessorInitializer();
 
   /**
@@ -176,6 +177,7 @@ private:
   HostMap hosts_;
   const TokenMap::Ptr token_map_;
   String local_dc_;
+  String local_rack_;
 
   RequestProcessorError error_code_;
   String error_message_;

--- a/src/round_robin_policy.cpp
+++ b/src/round_robin_policy.cpp
@@ -33,7 +33,7 @@ RoundRobinPolicy::RoundRobinPolicy()
 RoundRobinPolicy::~RoundRobinPolicy() { uv_rwlock_destroy(&available_rwlock_); }
 
 void RoundRobinPolicy::init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                            const String& local_dc) {
+                            const String& local_dc, const String& local_rack) {
   available_.resize(hosts.size());
   std::transform(hosts.begin(), hosts.end(), std::inserter(available_, available_.begin()),
                  GetAddress());

--- a/src/round_robin_policy.hpp
+++ b/src/round_robin_policy.hpp
@@ -31,7 +31,7 @@ public:
   ~RoundRobinPolicy();
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual CassHostDistance distance(const Host::Ptr& host) const;
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -205,13 +205,14 @@ public:
   SessionInitializer() { uv_mutex_destroy(&mutex_); }
 
   void initialize(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
-                  const HostMap& hosts, const TokenMap::Ptr& token_map, const String& local_dc) {
+                  const HostMap& hosts, const TokenMap::Ptr& token_map, const String& local_dc,
+		  const String& local_rack) {
     inc_ref();
 
     const size_t thread_count_io = remaining_ = session_->config().thread_count_io();
     for (size_t i = 0; i < thread_count_io; ++i) {
       RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-          connected_host, protocol_version, hosts, token_map, local_dc,
+          connected_host, protocol_version, hosts, token_map, local_dc, local_rack,
           bind_callback(&SessionInitializer::on_initialize, this)));
 
       RequestProcessorSettings settings(session_->config());
@@ -370,7 +371,7 @@ void Session::join() {
 
 void Session::on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                          const HostMap& hosts, const TokenMap::Ptr& token_map,
-                         const String& local_dc) {
+                         const String& local_dc, const String& local_rack) {
   int rc = 0;
 
   if (hosts.empty()) {
@@ -404,7 +405,7 @@ void Session::on_connect(const Host::Ptr& connected_host, ProtocolVersion protoc
   request_processor_count_ = 0;
   is_closing_ = false;
   SessionInitializer::Ptr initializer(new SessionInitializer(this));
-  initializer->initialize(connected_host, protocol_version, hosts, token_map, local_dc);
+  initializer->initialize(connected_host, protocol_version, hosts, token_map, local_dc, local_rack);
 }
 
 void Session::on_close() {

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -54,7 +54,7 @@ private:
 
   virtual void on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                           const HostMap& hosts, const TokenMap::Ptr& token_map,
-                          const String& local_dc);
+                          const String& local_dc, const String& local_rack);
 
   virtual void on_close();
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -160,7 +160,7 @@ void SessionBase::notify_closed() {
 
 void SessionBase::on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                              const HostMap& hosts, const TokenMap::Ptr& token_map,
-                             const String& local_dc) {
+                             const String& local_dc, const String& local_rack) {
   notify_connected();
 }
 
@@ -200,7 +200,7 @@ void SessionBase::on_initialize(ClusterConnector* connector) {
     }
 
     on_connect(cluster_->connected_host(), cluster_->protocol_version(),
-               cluster_->available_hosts(), cluster_->token_map(), cluster_->local_dc());
+               cluster_->available_hosts(), cluster_->token_map(), cluster_->local_dc(), cluster_->local_rack());
   } else {
     assert(!connector->is_canceled() && "Cluster connection process canceled");
     switch (connector->error_code()) {

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -117,7 +117,7 @@ protected:
    */
   virtual void on_connect(const Host::Ptr& connected_host, ProtocolVersion protocol_version,
                           const HostMap& hosts, const TokenMap::Ptr& token_map,
-                          const String& local_dc);
+                          const String& local_dc, const String& local_rack);
 
   /**
    * A callback called after the control connection fails to connect. By default

--- a/src/token_aware_policy.hpp
+++ b/src/token_aware_policy.hpp
@@ -35,7 +35,7 @@ public:
   virtual ~TokenAwarePolicy() {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc);
+                    const String& local_dc, const String& local_rack);
 
   virtual QueryPlan* new_query_plan(const String& keyspace, RequestHandler* request_handler,
                                     const TokenMap* token_map);
@@ -53,7 +53,9 @@ private:
         , child_plan_(child_plan)
         , replicas_(replicas)
         , index_(start_index)
-        , remaining_(replicas->size()) {}
+        , remaining_local_(replicas->size())
+        , remaining_remote_(replicas->size())
+        , remaining_remote2_(replicas->size()) {}
 
     Host::Ptr compute_next();
 
@@ -62,7 +64,9 @@ private:
     ScopedPtr<QueryPlan> child_plan_;
     CopyOnWriteHostVec replicas_;
     size_t index_;
-    size_t remaining_;
+    size_t remaining_local_;
+    size_t remaining_remote_;
+    size_t remaining_remote2_;
   };
 
   Random* random_;

--- a/tests/src/unit/tests/test_load_balancing.cpp
+++ b/tests/src/unit/tests/test_load_balancing.cpp
@@ -107,6 +107,7 @@ QueryCounts run_policy(LoadBalancingPolicy& policy, int count, CassConsistency c
   return counts;
 }
 
+// verify_dcs checks that all hosts in counts are from expected_dc.
 void verify_dcs(const QueryCounts& counts, const HostMap& hosts, const String& expected_dc) {
   for (QueryCounts::const_iterator it = counts.begin(), end = counts.end(); it != end; ++it) {
     HostMap::const_iterator host_it = hosts.find(it->first);
@@ -115,6 +116,7 @@ void verify_dcs(const QueryCounts& counts, const HostMap& hosts, const String& e
   }
 }
 
+// verify_query_counts checks that each host was used expected_count times.
 void verify_query_counts(const QueryCounts& counts, int expected_count) {
   for (QueryCounts::const_iterator it = counts.begin(), end = counts.end(); it != end; ++it) {
     EXPECT_EQ(expected_count, it->second);

--- a/tests/src/unit/tests/test_load_balancing.cpp
+++ b/tests/src/unit/tests/test_load_balancing.cpp
@@ -21,6 +21,7 @@
 #include "blacklist_policy.hpp"
 #include "constants.hpp"
 #include "dc_aware_policy.hpp"
+#include "rack_aware_policy.hpp"
 #include "event_loop.hpp"
 #include "latency_aware_policy.hpp"
 #include "murmur3.hpp"
@@ -45,6 +46,9 @@ using namespace datastax::internal::core;
 const String LOCAL_DC = "local";
 const String REMOTE_DC = "remote";
 const String BACKUP_DC = "backup";
+
+const String LOCAL_RACK = "local";
+const String REMOTE_RACK = "remote";
 
 #define VECTOR_FROM(t, a) Vector<t>(a, a + sizeof(a) / sizeof(a[0]))
 
@@ -116,6 +120,17 @@ void verify_dcs(const QueryCounts& counts, const HostMap& hosts, const String& e
   }
 }
 
+// verify_racks checks that all hosts in counts are from expected_dc and expected_rack.
+void verify_racks(const QueryCounts& counts, const HostMap& hosts, const String& expected_dc,
+                  const String& expected_rack) {
+  for (QueryCounts::const_iterator it = counts.begin(), end = counts.end(); it != end; ++it) {
+    HostMap::const_iterator host_it = hosts.find(it->first);
+    ASSERT_NE(host_it, hosts.end());
+    EXPECT_EQ(expected_dc, host_it->second->dc());
+    EXPECT_EQ(expected_rack, host_it->second->rack());
+  }
+}
+
 // verify_query_counts checks that each host was used expected_count times.
 void verify_query_counts(const QueryCounts& counts, int expected_count) {
   for (QueryCounts::const_iterator it = counts.begin(), end = counts.end(); it != end; ++it) {
@@ -184,7 +199,7 @@ void test_dc_aware_policy(size_t local_count, size_t remote_count) {
   populate_hosts(local_count, "rack", LOCAL_DC, &hosts);
   populate_hosts(remote_count, "rack", REMOTE_DC, &hosts);
   DCAwarePolicy policy(LOCAL_DC, remote_count, false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   const size_t total_hosts = local_count + remote_count;
 
@@ -200,7 +215,7 @@ TEST(RoundRobinLoadBalancingUnitTest, Simple) {
   populate_hosts(2, "rack", "dc", &hosts);
 
   RoundRobinPolicy policy;
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   // start on first elem
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
@@ -222,7 +237,7 @@ TEST(RoundRobinLoadBalancingUnitTest, OnAdd) {
   populate_hosts(2, "rack", "dc", &hosts);
 
   RoundRobinPolicy policy;
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   // baseline
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
@@ -245,7 +260,7 @@ TEST(RoundRobinLoadBalancingUnitTest, OnRemove) {
   populate_hosts(3, "rack", "dc", &hosts);
 
   RoundRobinPolicy policy;
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
   SharedRefPtr<Host> host = hosts.begin()->second;
@@ -266,7 +281,7 @@ TEST(RoundRobinLoadBalancingUnitTest, OnUpAndDown) {
   populate_hosts(3, "rack", "dc", &hosts);
 
   RoundRobinPolicy policy;
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp_before1(policy.new_query_plan("ks", NULL, NULL));
   ScopedPtr<QueryPlan> qp_before2(policy.new_query_plan("ks", NULL, NULL));
@@ -312,7 +327,7 @@ TEST(RoundRobinLoadBalancingUnitTest, VerifyEqualDistribution) {
   populate_hosts(3, "rack", "dc", &hosts);
 
   RoundRobinPolicy policy;
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   { // All nodes
     QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
@@ -353,7 +368,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, SomeDatacenterLocalUnspecified) {
   h->set_rack_and_dc("", "");
 
   DCAwarePolicy policy(LOCAL_DC, 1, false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
 
@@ -368,7 +383,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, SingleLocalDown) {
   populate_hosts(1, "rack", REMOTE_DC, &hosts);
 
   DCAwarePolicy policy(LOCAL_DC, 1, false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp_before(
       policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
@@ -395,7 +410,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, AllLocalRemovedReturned) {
   populate_hosts(1, "rack", REMOTE_DC, &hosts);
 
   DCAwarePolicy policy(LOCAL_DC, 1, false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp_before(
       policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
@@ -427,7 +442,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, RemoteRemovedReturned) {
   SharedRefPtr<Host> target_host = hosts[target_addr];
 
   DCAwarePolicy policy(LOCAL_DC, 1, false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp_before(
       policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
@@ -458,7 +473,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, UsedHostsPerDatacenter) {
 
   for (size_t used_hosts = 0; used_hosts < 4; ++used_hosts) {
     DCAwarePolicy policy(LOCAL_DC, used_hosts, false);
-    policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+    policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
     Vector<size_t> seq;
@@ -491,7 +506,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, AllowRemoteDatacentersForLocalConsist
     // Not allowing remote DCs for local CLs
     bool allow_remote_dcs_for_local_cl = false;
     DCAwarePolicy policy(LOCAL_DC, 3, !allow_remote_dcs_for_local_cl);
-    policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+    policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
     // Set local CL
     QueryRequest::Ptr request(new QueryRequest("", 0));
@@ -509,7 +524,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, AllowRemoteDatacentersForLocalConsist
     // Allowing remote DCs for local CLs
     bool allow_remote_dcs_for_local_cl = true;
     DCAwarePolicy policy(LOCAL_DC, 3, !allow_remote_dcs_for_local_cl);
-    policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+    policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
     // Set local CL
     QueryRequest::Ptr request(new QueryRequest("", 0));
@@ -532,7 +547,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, StartWithEmptyLocalDatacenter) {
   // Set local DC using connected host
   {
     DCAwarePolicy policy("", 0, false);
-    policy.init(hosts[Address("2.0.0.0", 9042)], hosts, NULL, "");
+    policy.init(hosts[Address("2.0.0.0", 9042)], hosts, NULL, "", "");
 
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
     const size_t seq[] = { 2, 3, 4 };
@@ -542,7 +557,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, StartWithEmptyLocalDatacenter) {
   // Set local DC using first host with non-empty DC
   {
     DCAwarePolicy policy("", 0, false);
-    policy.init(SharedRefPtr<Host>(new Host(Address("0.0.0.0", 9042))), hosts, NULL, "");
+    policy.init(SharedRefPtr<Host>(new Host(Address("0.0.0.0", 9042))), hosts, NULL, "", "");
 
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
     const size_t seq[] = { 1 };
@@ -562,7 +577,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, VerifyEqualDistributionLocalDc) {
   populate_hosts(3, "rack", REMOTE_DC, &hosts);
 
   DCAwarePolicy policy("", 0, false);
-  policy.init(hosts.begin()->second, hosts, NULL, "");
+  policy.init(hosts.begin()->second, hosts, NULL, "", "");
 
   { // All local nodes
     QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
@@ -605,7 +620,7 @@ TEST(DatacenterAwareLoadBalancingUnitTest, VerifyEqualDistributionRemoteDc) {
   populate_hosts(3, "rack", REMOTE_DC, &hosts);
 
   DCAwarePolicy policy("", 3, false); // Allow all remote DC nodes
-  policy.init(hosts.begin()->second, hosts, NULL, "");
+  policy.init(hosts.begin()->second, hosts, NULL, "", "");
 
   Host::Ptr remote_dc_node1;
   { // Mark down all local nodes
@@ -621,6 +636,355 @@ TEST(DatacenterAwareLoadBalancingUnitTest, VerifyEqualDistributionRemoteDc) {
     QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
     verify_dcs(counts, hosts, REMOTE_DC);
     ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_down(remote_dc_node1->address());
+
+  { // One remote node down
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, REMOTE_DC);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+
+  policy.on_host_up(remote_dc_node1);
+
+  { // All remote nodes again
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, REMOTE_DC);
+    ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_removed(remote_dc_node1);
+
+  { // One remote node removed
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, REMOTE_DC);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+}
+
+// Check that host with unspecified rack and DC is last.
+TEST(RackAwareLoadBalancingUnitTest, SomeDatacenterRackLocalUnspecified) {
+  const size_t total_hosts = 3;
+  HostMap hosts;
+  populate_hosts(total_hosts, LOCAL_RACK, LOCAL_DC, &hosts);
+  Host* h = hosts.begin()->second.get();
+  h->set_rack_and_dc("", "");
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  // Use CL=ONE to allow remote DCs.
+  QueryRequest::Ptr request(new QueryRequest("", 0));
+  request->set_consistency(CASS_CONSISTENCY_ONE);
+  SharedRefPtr<RequestHandler> request_handler(
+      new RequestHandler(request, ResponseFuture::Ptr()));
+
+  ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", request_handler.get(), NULL));
+
+  const size_t seq[] = { 2, 3, 1 };
+  verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+}
+
+// Check that host with unspecified rack is last.
+TEST(RackAwareLoadBalancingUnitTest, SomeRackLocalUnspecified) {
+  const size_t total_hosts = 3;
+  HostMap hosts;
+  populate_hosts(total_hosts, LOCAL_RACK, LOCAL_DC, &hosts);
+  Host* h = hosts.begin()->second.get();
+  h->set_rack_and_dc("", LOCAL_DC);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  // Use CL=ONE to allow remote DCs.
+  QueryRequest::Ptr request(new QueryRequest("", 0));
+  request->set_consistency(CASS_CONSISTENCY_ONE);
+  SharedRefPtr<RequestHandler> request_handler(
+      new RequestHandler(request, ResponseFuture::Ptr()));
+
+  ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", request_handler.get(), NULL));
+
+  const size_t seq[] = { 2, 3, 1 };
+  verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+}
+
+// Check that down host is not returned.
+TEST(RackAwareLoadBalancingUnitTest, SingleLocalDown) {
+  HostMap hosts;
+  populate_hosts(3, LOCAL_RACK, LOCAL_DC, &hosts);
+  SharedRefPtr<Host> target_host = hosts.begin()->second;
+  populate_hosts(1, REMOTE_RACK, LOCAL_DC, &hosts);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  ScopedPtr<QueryPlan> qp_before(
+      policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
+  ScopedPtr<QueryPlan> qp_after(
+      policy.new_query_plan("ks", NULL, NULL)); // should not have down host ptr in plan
+
+  policy.on_host_down(target_host->address());
+  {
+    const size_t seq[] = { 2, 3, 4 };
+    verify_sequence(qp_before.get(), VECTOR_FROM(size_t, seq));
+  }
+
+  policy.on_host_up(target_host);
+  {
+    const size_t seq[] = { 2, 3, 1, 4 }; // local dc wrapped before remote offered
+    verify_sequence(qp_after.get(), VECTOR_FROM(size_t, seq));
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, AllLocalRemovedReturned) {
+  HostMap hosts;
+  populate_hosts(1, LOCAL_RACK, LOCAL_DC, &hosts);
+  SharedRefPtr<Host> target_host = hosts.begin()->second;
+  populate_hosts(1, REMOTE_RACK, LOCAL_DC, &hosts);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  ScopedPtr<QueryPlan> qp_before(
+      policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
+  policy.on_host_down(target_host->address());
+  ScopedPtr<QueryPlan> qp_after(
+      policy.new_query_plan("ks", NULL, NULL)); // should not have down host ptr in plan
+
+  {
+    const size_t seq[] = { 2 };
+    verify_sequence(qp_before.get(), VECTOR_FROM(size_t, seq));
+    verify_sequence(qp_after.get(), VECTOR_FROM(size_t, seq));
+  }
+
+  policy.on_host_up(target_host);
+
+  // make sure we get the local node first after on_up
+  ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+  {
+    const size_t seq[] = { 1, 2 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, RemoteRemovedReturned) {
+  HostMap hosts;
+  populate_hosts(1, LOCAL_RACK, LOCAL_DC, &hosts);
+  populate_hosts(1, REMOTE_RACK, LOCAL_DC, &hosts);
+  Address target_addr("2.0.0.0", 9042);
+  SharedRefPtr<Host> target_host = hosts[target_addr];
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  ScopedPtr<QueryPlan> qp_before(
+      policy.new_query_plan("ks", NULL, NULL)); // has down host ptr in plan
+  policy.on_host_down(target_host->address());
+  ScopedPtr<QueryPlan> qp_after(
+      policy.new_query_plan("ks", NULL, NULL)); // should not have down host ptr in plan
+
+  {
+    const size_t seq[] = { 1 };
+    verify_sequence(qp_before.get(), VECTOR_FROM(size_t, seq));
+    verify_sequence(qp_after.get(), VECTOR_FROM(size_t, seq));
+  }
+
+  policy.on_host_up(target_host);
+
+  // make sure we get both nodes, correct order after
+  ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+  {
+    const size_t seq[] = { 1, 2 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, DoNotAllowRemoteDatacentersForLocalConsistencyLevel) {
+  HostMap hosts;
+  populate_hosts(3, "rack", LOCAL_DC, &hosts);
+  populate_hosts(3, "rack", REMOTE_DC, &hosts);
+
+  // Not allowing remote DCs for local CLs
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
+
+  // Set local CL
+  QueryRequest::Ptr request(new QueryRequest("", 0));
+  request->set_consistency(CASS_CONSISTENCY_LOCAL_ONE);
+  SharedRefPtr<RequestHandler> request_handler(
+      new RequestHandler(request, ResponseFuture::Ptr()));
+
+  // Check for only local hosts are used
+  ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", request_handler.get(), NULL));
+  const size_t seq[] = { 1, 2, 3 };
+  verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+}
+
+TEST(RackAwareLoadBalancingUnitTest, StartWithEmptyLocalRack) {
+  HostMap hosts;
+  populate_hosts(1, REMOTE_RACK, LOCAL_DC, &hosts);
+  populate_hosts(3, LOCAL_RACK, LOCAL_DC, &hosts);
+
+  // Set local rack using connected host
+  {
+    RackAwarePolicy policy("", "");
+    policy.init(hosts[Address("2.0.0.0", 9042)], hosts, NULL, "", "");
+
+    ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+    const size_t seq[] = { 2, 3, 4, 1 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+
+  // Set local rack using first host with non-empty rack
+  {
+    RackAwarePolicy policy("", "");
+    policy.init(SharedRefPtr<Host>(new Host(Address("0.0.0.0", 9042))), hosts, NULL, "", "");
+
+    ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+    const size_t seq[] = { 1, 3, 4, 2 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, StartWithEmptyLocalDatacenter) {
+  HostMap hosts;
+  populate_hosts(1, "rack", REMOTE_DC, &hosts);
+  populate_hosts(3, "rack", LOCAL_DC, &hosts);
+
+  // Set local DC using connected host
+  {
+    RackAwarePolicy policy("", "");
+    policy.init(hosts[Address("2.0.0.0", 9042)], hosts, NULL, "", "");
+
+    ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+    const size_t seq[] = { 2, 3, 4 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+
+  // Set local DC using first host with non-empty DC
+  {
+    RackAwarePolicy policy("", "");
+    policy.init(SharedRefPtr<Host>(new Host(Address("0.0.0.0", 9042))), hosts, NULL, "", "");
+
+    ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
+    const size_t seq[] = { 1 };
+    verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, VerifyEqualDistributionLocalRack) {
+  HostMap hosts;
+  populate_hosts(3, LOCAL_RACK, LOCAL_DC, &hosts);
+  populate_hosts(3, REMOTE_RACK, LOCAL_DC, &hosts);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(hosts.begin()->second, hosts, NULL, "", "");
+
+  { // All local nodes
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_racks(counts, hosts, LOCAL_DC, LOCAL_RACK);
+    ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_down(hosts.begin()->first);
+
+  { // One local node down
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_racks(counts, hosts, LOCAL_DC, LOCAL_RACK);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+
+  policy.on_host_up(hosts.begin()->second);
+
+  { // All local nodes again
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_racks(counts, hosts, LOCAL_DC, LOCAL_RACK);
+    ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_removed(hosts.begin()->second);
+
+  { // One local node removed
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_racks(counts, hosts, LOCAL_DC, LOCAL_RACK);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, VerifyEqualDistributionLocalDc) {
+  HostMap hosts;
+  populate_hosts(3, "rack", LOCAL_DC, &hosts);
+  populate_hosts(3, "rack", REMOTE_DC, &hosts);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(hosts.begin()->second, hosts, NULL, "", "");
+
+  { // All local nodes
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, LOCAL_DC);
+    ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_down(hosts.begin()->first);
+
+  { // One local node down
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, LOCAL_DC);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+
+  policy.on_host_up(hosts.begin()->second);
+
+  { // All local nodes again
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, LOCAL_DC);
+    ASSERT_EQ(counts.size(), 3u);
+    verify_query_counts(counts, 4);
+  }
+
+  policy.on_host_removed(hosts.begin()->second);
+
+  { // One local node removed
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, LOCAL_DC);
+    ASSERT_EQ(counts.size(), 2u);
+    verify_query_counts(counts, 6);
+  }
+}
+
+TEST(RackAwareLoadBalancingUnitTest, VerifyEqualDistributionRemoteDc) {
+  HostMap hosts;
+  populate_hosts(3, LOCAL_RACK, LOCAL_DC, &hosts);
+  populate_hosts(3, LOCAL_RACK, REMOTE_DC, &hosts);
+
+  RackAwarePolicy policy(LOCAL_DC, LOCAL_RACK);
+  policy.init(hosts.begin()->second, hosts, NULL, "", "");
+
+  Host::Ptr remote_dc_node1;
+  { // Mark down all local nodes
+    HostMap::iterator it = hosts.begin();
+    for (int i = 0; i < 3; ++i) {
+      policy.on_host_down(it->first);
+      it++;
+    }
+    remote_dc_node1 = it->second;
+  }
+
+  { // All remote nodes
+    QueryCounts counts(run_policy(policy, 12, CASS_CONSISTENCY_ONE));
+    verify_dcs(counts, hosts, REMOTE_DC);
+    ASSERT_EQ(counts.size(), 3u) << "Should use all hosts from remote DC";
     verify_query_counts(counts, 4);
   }
 
@@ -679,7 +1043,7 @@ TEST(TokenAwareLoadBalancingUnitTest, Simple) {
   token_map->build();
 
   TokenAwarePolicy policy(new RoundRobinPolicy(), false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   QueryRequest::Ptr request(new QueryRequest("", 1));
   const char* value = "kjdfjkldsdjkl"; // hash: 9024137376112061887
@@ -725,12 +1089,12 @@ TEST(TokenAwareLoadBalancingUnitTest, NetworkTopology) {
 
   // Tokens
   // 1.0.0.0 local  -6588122883467697006
-  // 2.0.0.0 remote -3952873730080618204
-  // 3.0.0.0 local  -1317624576693539402
-  // 4.0.0.0 remote  1317624576693539400
-  // 5.0.0.0 local   3952873730080618202
+  // 2.0.0.0 remote -3952873730080618204 (replica for -5434086359492102041)
+  // 3.0.0.0 local  -1317624576693539402 (replica for -5434086359492102041)
+  // 4.0.0.0 remote  1317624576693539400 (replica for -5434086359492102041)
+  // 5.0.0.0 local   3952873730080618202 (replica for -5434086359492102041)
   // 6.0.0.0 remote  6588122883467697004
-  // 7.0.0.0 local   9223372036854775806
+  // 7.0.0.0 local   9223372036854775806 (replica for -5434086359492102041)
 
   const uint64_t partition_size = CASS_UINT64_MAX / num_hosts;
   Murmur3Partitioner::Token token = CASS_INT64_MIN + static_cast<int64_t>(partition_size);
@@ -752,7 +1116,7 @@ TEST(TokenAwareLoadBalancingUnitTest, NetworkTopology) {
   token_map->build();
 
   TokenAwarePolicy policy(new DCAwarePolicy(LOCAL_DC, num_hosts / 2, false), false);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   QueryRequest::Ptr request(new QueryRequest("", 1));
   const char* value = "abc"; // hash: -5434086359492102041
@@ -762,7 +1126,7 @@ TEST(TokenAwareLoadBalancingUnitTest, NetworkTopology) {
 
   {
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("test", request_handler.get(), token_map.get()));
-    const size_t seq[] = { 3, 5, 7, 1, 4, 6, 2 };
+    const size_t seq[] = { 3, 5, 7, 2, 4, 1, 6 };
     verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
   }
 
@@ -772,7 +1136,7 @@ TEST(TokenAwareLoadBalancingUnitTest, NetworkTopology) {
 
   {
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("test", request_handler.get(), token_map.get()));
-    const size_t seq[] = { 3, 5, 7, 4, 6, 2 };
+    const size_t seq[] = { 3, 5, 7, 2, 4, 6 };
     verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
   }
 
@@ -784,7 +1148,7 @@ TEST(TokenAwareLoadBalancingUnitTest, NetworkTopology) {
 
   {
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("test", request_handler.get(), token_map.get()));
-    const size_t seq[] = { 5, 7, 1, 6, 2, 4 };
+    const size_t seq[] = { 5, 7, 2, 4, 1, 6 };
     verify_sequence(qp.get(), VECTOR_FROM(size_t, seq));
   }
 }
@@ -826,7 +1190,7 @@ TEST(TokenAwareLoadBalancingUnitTest, ShuffleReplicas) {
   HostVec not_shuffled;
   {
     TokenAwarePolicy policy(new RoundRobinPolicy(), false); // Not shuffled
-    policy.init(SharedRefPtr<Host>(), hosts, &random, "");
+    policy.init(SharedRefPtr<Host>(), hosts, &random, "", "");
     ScopedPtr<QueryPlan> qp1(policy.new_query_plan("test", request_handler.get(), token_map.get()));
     for (int i = 0; i < num_hosts; ++i) {
       not_shuffled.push_back(qp1->compute_next());
@@ -844,7 +1208,7 @@ TEST(TokenAwareLoadBalancingUnitTest, ShuffleReplicas) {
   // Verify that the shuffle setting does indeed shuffle the replicas
   {
     TokenAwarePolicy shuffle_policy(new RoundRobinPolicy(), true); // Shuffled
-    shuffle_policy.init(SharedRefPtr<Host>(), hosts, &random, "");
+    shuffle_policy.init(SharedRefPtr<Host>(), hosts, &random, "", "");
 
     HostVec shuffled_previous;
     ScopedPtr<QueryPlan> qp(
@@ -942,7 +1306,7 @@ TEST(LatencyAwareLoadBalancingUnitTest, Simple) {
   HostMap hosts;
   populate_hosts(num_hosts, "rack1", LOCAL_DC, &hosts);
   LatencyAwarePolicy policy(new RoundRobinPolicy(), settings);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   // Record some latencies with 100 ns being the minimum
   for (HostMap::iterator i = hosts.begin(); i != hosts.end(); ++i) {
@@ -1004,7 +1368,7 @@ TEST(LatencyAwareLoadBalancingUnitTest, MinAverageUnderMinMeasured) {
   HostMap hosts;
   populate_hosts(num_hosts, "rack1", LOCAL_DC, &hosts);
   LatencyAwarePolicy policy(new RoundRobinPolicy(), settings);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   int count = 1;
   for (HostMap::iterator i = hosts.begin(); i != hosts.end(); ++i) {
@@ -1038,7 +1402,7 @@ TEST(WhitelistLoadBalancingUnitTest, Hosts) {
   whitelist_hosts.push_back("37.0.0.0");
   whitelist_hosts.push_back("83.0.0.0");
   WhitelistPolicy policy(new RoundRobinPolicy(), whitelist_hosts);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
 
@@ -1059,7 +1423,7 @@ TEST(WhitelistLoadBalancingUnitTest, Datacenters) {
   whitelist_dcs.push_back(LOCAL_DC);
   whitelist_dcs.push_back(REMOTE_DC);
   WhitelistDCPolicy policy(new RoundRobinPolicy(), whitelist_dcs);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
 
@@ -1079,7 +1443,7 @@ TEST(BlacklistLoadBalancingUnitTest, Hosts) {
   blacklist_hosts.push_back("2.0.0.0");
   blacklist_hosts.push_back("3.0.0.0");
   BlacklistPolicy policy(new RoundRobinPolicy(), blacklist_hosts);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
 
@@ -1100,7 +1464,7 @@ TEST(BlacklistLoadBalancingUnitTest, Datacenters) {
   blacklist_dcs.push_back(LOCAL_DC);
   blacklist_dcs.push_back(REMOTE_DC);
   BlacklistDCPolicy policy(new RoundRobinPolicy(), blacklist_dcs);
-  policy.init(SharedRefPtr<Host>(), hosts, NULL, "");
+  policy.init(SharedRefPtr<Host>(), hosts, NULL, "", "");
 
   ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
 

--- a/tests/src/unit/tests/test_load_balancing.cpp
+++ b/tests/src/unit/tests/test_load_balancing.cpp
@@ -93,7 +93,7 @@ typedef Map<Address, int> QueryCounts;
 
 QueryCounts run_policy(LoadBalancingPolicy& policy, int count) {
   QueryCounts counts;
-  for (int i = 0; i < 12; ++i) {
+  for (int i = 0; i < count; ++i) {
     ScopedPtr<QueryPlan> qp(policy.new_query_plan("ks", NULL, NULL));
     Host::Ptr host(qp->compute_next());
     if (host) {

--- a/tests/src/unit/tests/test_request_processor.cpp
+++ b/tests/src/unit/tests/test_request_processor.cpp
@@ -37,7 +37,7 @@ public:
       , hosts_(new HostVec()) {}
 
   virtual void init(const Host::Ptr& connected_host, const HostMap& hosts, Random* random,
-                    const String& local_dc) {
+                    const String& local_dc, const String& local_rack) {
     hosts_->reserve(hosts.size());
     std::transform(hosts.begin(), hosts.end(), std::back_inserter(*hosts_), GetHost());
   }
@@ -277,7 +277,7 @@ TEST_F(RequestProcessorUnitTest, Simple) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   initializer->initialize(event_loop());
@@ -296,7 +296,7 @@ TEST_F(RequestProcessorUnitTest, CloseWithRequestsPending) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   initializer->initialize(event_loop());
@@ -334,7 +334,7 @@ TEST_F(RequestProcessorUnitTest, Auth) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -359,7 +359,7 @@ TEST_F(RequestProcessorUnitTest, Ssl) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   initializer->with_settings(settings)->initialize(event_loop());
@@ -383,7 +383,7 @@ TEST_F(RequestProcessorUnitTest, NotifyAddRemoveHost) {
   Future::Ptr up_future(new Future());
   Future::Ptr down_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -415,7 +415,7 @@ TEST_F(RequestProcessorUnitTest, CloseDuringReconnect) {
   Future::Ptr close_future(new Future());
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -450,7 +450,7 @@ TEST_F(RequestProcessorUnitTest, CloseDuringAddNewHost) {
   Future::Ptr close_future(new Future());
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   CloseListener::Ptr listener(new CloseListener(close_future));
@@ -480,7 +480,7 @@ TEST_F(RequestProcessorUnitTest, PoolDown) {
   Future::Ptr up_future(new Future());
   Future::Ptr down_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   UpDownListener::Ptr listener(new UpDownListener(up_future, down_future, target_host));
@@ -510,7 +510,7 @@ TEST_F(RequestProcessorUnitTest, PoolUp) {
   Future::Ptr up_future(new Future());
   Future::Ptr down_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -538,7 +538,7 @@ TEST_F(RequestProcessorUnitTest, InvalidAuth) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -564,7 +564,7 @@ TEST_F(RequestProcessorUnitTest, InvalidSsl) {
 
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   SslContext::Ptr ssl_context(SslContextFactory::create()); // No trusted cert
@@ -600,7 +600,7 @@ TEST_F(RequestProcessorUnitTest, RollingRestart) {
   HostMap hosts(generate_hosts());
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   RequestProcessorSettings settings;
@@ -632,7 +632,7 @@ TEST_F(RequestProcessorUnitTest, NoHostsAvailable) {
   HostMap hosts(generate_hosts());
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   initializer->with_listener(listener.get())->initialize(event_loop());
@@ -668,7 +668,7 @@ TEST_F(RequestProcessorUnitTest, RequestTimeout) {
   HostMap hosts(generate_hosts());
   Future::Ptr connect_future(new Future());
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
 
   initializer->with_listener(listener.get())->initialize(event_loop());
@@ -718,7 +718,7 @@ TEST_F(RequestProcessorUnitTest, LowNumberOfStreams) {
   settings.request_queue_size = 2 * CASS_MAX_STREAMS + 1; // Create a request queue with enough room
 
   RequestProcessorInitializer::Ptr initializer(new RequestProcessorInitializer(
-      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "",
+      hosts.begin()->second, PROTOCOL_VERSION, hosts, TokenMap::Ptr(), "", "",
       bind_callback(on_connected, connect_future.get())));
   initializer->with_settings(settings)->with_listener(listener.get())->initialize(event_loop());
 


### PR DESCRIPTION
We need to prefer local rack as there are higher network costs
when communicating with nodes in remote rack.

This policy prefers nodes from the local rack, then local datacenter
and then other nodes.

The new RackAwarePolicy is similar to DCAwarePolicy,
but does not have the deprecated options.
TokenAwarePolicy and other code needed to be modified
so that the local rack is propagated.

The TokenAware policy was changed to prefer replicas in remote
rack / remote DC before trying non-replica nodes.
It does not make much sense to not try the replicas and
trying the replicas simplifies the code as now we have three
levels local/remote/remote2.

This change might not be backwards-compatible,
we don't know what exactly this project guarantees in terms of
backwards compatibility.

Co-Authored-By: Peter Navrátil <peter.navratil@kiwi.com>